### PR TITLE
Make sure to format hex as uppercase (found discrepancy while testing usb control)

### DIFF
--- a/src/embodycodec/attributes.py
+++ b/src/embodycodec/attributes.py
@@ -99,7 +99,7 @@ class SerialNoAttribute(Attribute):
     value: int
 
     def formatted_value(self) -> Optional[str]:
-        return self.value.to_bytes(8, "big", signed=True).hex() if self.value else None
+        return ''.join('{:02X}'.format(x) for x in self.value.to_bytes(8, "big", signed=True)) if (self.value != None) else None
 
 
 @dataclass


### PR DESCRIPTION
Found discrepancy while testing usb control
get_serial_no() in EmbodySendHelper relies on SerialNoAttribute.formatted_value() which returns lower case data while BLE access using EmbodySerialReporter.read_ble_serial_no() uses str(serial_no, "ascii") on bytearray which returns uppercase.