### PR TITLE
Uppercase formatted serialno attribute value

### DIFF
--- a/src/embodycodec/attributes.py
+++ b/src/embodycodec/attributes.py
@@ -99,7 +99,11 @@ class SerialNoAttribute(Attribute):
     value: int
 
     def formatted_value(self) -> Optional[str]:
-        return self.value.to_bytes(8, "big", signed=True).hex() if self.value else None
+        return (
+            self.value.to_bytes(8, "big", signed=True).hex().upper()
+            if self.value
+            else None
+        )
 
 
 @dataclass

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -13,7 +13,7 @@ def test_encode_decode_serial_no() -> None:
 
 def test_serial_no_attribute_format_value() -> None:
     assert (
-        attributes.SerialNoAttribute(12345678).formatted_value() == "0000000000bc614e"
+        attributes.SerialNoAttribute(12345678).formatted_value() == "0000000000BC614E"
     )
 
 


### PR DESCRIPTION
Changes the `SerialNoAttribute` class in `src/embodycodec/attributes.py` and its corresponding test in `tests/test_attribute.py`. The main alteration is the adjustment of the `formatted_value` method to return the hexadecimal representation of the value in uppercase. This change is also reflected in the test case for this method.

Key changes include:

* [`src/embodycodec/attributes.py`](diffhunk://#diff-3ab55f528283af7adc0c62aae1a95a8616ac5ddb4292843c8d68af944b90ab26L102-R106): The `formatted_value` method in the `SerialNoAttribute` class has been modified to return the hexadecimal representation of the value in uppercase. Previously, it returned the hexadecimal representation in lowercase.
* [`tests/test_attribute.py`](diffhunk://#diff-19f7e489bdcc6bde8b5d53ccc4ce456e1d78ce4a2881fb9387f167cab9d66a60L16-R16): The test case `test_serial_no_attribute_format_value` was updated to reflect the change in the `formatted_value` method. The expected output is now an uppercase hexadecimal string.