### PR TITLE
Bump release version to 1.0.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embody-codec"
-version = "1.0.32"
+version = "1.0.33"
 description = "Embody Codec"
 authors = [{name = "Aidee Health AS", email = "hello@aidee.io"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "embody-codec"
-version = "1.0.32"
+version = "1.0.33"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This pull request includes a version bump for the `embody-codec` project in the `pyproject.toml` file. The version has been updated from `1.0.32` to `1.0.33`, likely indicating a minor update or patch.