### PR TITLE
Maintenance release 1.0.34

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: salsify/action-detect-and-tag-new-version@v2.0.3
         with:
           version-command: |
-            bash -o pipefail -c "grep -m 1 'version = ' pyproject.toml | awk -F '\"' '{print $2}'"
+            bash -o pipefail -c "grep -m 1 'version = ' pyproject.toml | sed -E 's/.*version = \"([^\"]+)\".*/\1/'"
 
       - name: Bump version for developmental release
         if: ${{ ! steps.check-version.outputs.tag }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embody-codec"
-version = "1.0.33"
+version = "1.0.34"
 description = "Embody Codec"
 authors = [{name = "Aidee Health AS", email = "hello@aidee.io"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "embody-codec"
-version = "1.0.33"
+version = "1.0.34"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This pull request includes updates to the versioning process and a version bump in the `pyproject.toml` file. The most important changes are summarized below:

### Versioning process improvement:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L47-R47): Updated the `version-command` in the release workflow to use `sed` for extracting the version from `pyproject.toml`, replacing the previous `awk` command. This change simplifies and improves the readability of the command.

### Version bump:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Incremented the project version from `1.0.33` to `1.0.34`.