### PR TITLE
Maintenance release 1.0.40: sharpen ruff/ty, drop Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11","3.12","3.13"]
+        python-version: ["3.12","3.13"]
       fail-fast: false
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.5
+    rev: v0.15.15
     hooks:
       # Run the linter (replaces flake8).
       - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Request features on the [Issue Tracker].
 
 ## How to set up your development environment
 
-You need Python 3.11+ and the following tools:
+You need Python 3.12+ and the following tools:
 
 - [UV] - Fast Python package installer and resolver
 - [tox] - Standardized testing in Python

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is a Python based implementation library for the Aidee EmBody communication
 ## Requirements
 
 - This library does not require any external libraries
-- Requires Python 3.11+
+- Requires Python 3.12+
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "embody-codec"
-version = "1.0.39"
+version = "1.0.40"
 description = "Embody Codec"
 authors = [{name = "Aidee Health AS", email = "hello@aidee.io"}]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.12,<4.0"
 classifiers = ["Development Status :: 5 - Production/Stable"]
 
 [project.urls]
@@ -17,8 +17,8 @@ Repository = "https://github.com/aidee-health/embody-codec"
 [dependency-groups]
 dev = [
     "pytest>=7.2.0",
-    "ruff>=0.11.5",
-    "ty>=0.0.2",
+    "ruff>=0.15.15",
+    "ty>=0.0.42",
     "pre-commit>=2.16.0",
     "pre-commit-hooks>=4.1.0",
 ]
@@ -44,13 +44,8 @@ source = ["embodycodec", "tests"]
 show_missing = true
 fail_under = 2
 
-[tool.isort]
-profile = "black"
-force_single_line = true
-lines_after_imports = 2
-
 [tool.ty.environment]
-python-version = "3.11"  # Matches project requires-python
+python-version = "3.12"  # Matches project requires-python
 
 [tool.ty.rules]
 # Core type safety rules (stricter than previous mypy configuration)
@@ -62,14 +57,14 @@ call-non-callable = "error"         # Catch calling non-functions
 # Additional strictness
 deprecated = "warn"                 # Warn on deprecated usage
 redundant-cast = "warn"            # Catch unnecessary casts
-# Future consideration: Enable more strict rules after team is comfortable
+missing-override-decorator = "error"  # Require @override on overriding methods (catches signature drift)
 
 [tool.ty.terminal]
 output-format = "full"             # Provides detailed error messages with full context
-error-on-warning = false           # Don't fail on warnings initially
+error-on-warning = true            # Treat warnings (deprecated, redundant-cast) as failures
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
@@ -87,6 +82,7 @@ select = [
     "RUF",  # Ruff-specific rules
     "PTH",  # use pathlib
     "PL",   # Pylint
+    "PIE",  # flake8-pie
 ]
 ignore = [
     "E203",   # Whitespace before ':'
@@ -102,10 +98,7 @@ ignore = [
     "D101",   # Missing docstring in public class
     "B024",   # Abstract class with no abstract methods
     "B905",   # zip() without an explicit strict= parameter
-    "F401",   # Unused imports
     "PLR2004", # Magic value used in comparison
-    "I001",   # isort: skip
-    "PTH123", # pathlib: skip
     "RUF012", # mutable-class-default
     "PLR0911", # Too many return statements
     "PLR0912", # Too many branches
@@ -114,6 +107,10 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.isort]
+force-single-line = true
+lines-after-imports = 2
 
 [tool.ruff.lint.mccabe]
 max-complexity = 50

--- a/src/embodycodec/attributes.py
+++ b/src/embodycodec/attributes.py
@@ -11,12 +11,14 @@ import struct
 from abc import ABC
 from dataclasses import astuple
 from dataclasses import dataclass
-from datetime import datetime
 from datetime import UTC
+from datetime import datetime
 from typing import Any
 from typing import TypeVar
+from typing import override
 
 from embodycodec import types as t
+
 
 # Temperature sensor conversion factor (degrees Celsius per raw unit)
 # This factor converts raw sensor values to degrees Celsius
@@ -66,14 +68,17 @@ class ZeroTerminatedStringAttribute(Attribute, ABC):
 
     value: str
 
+    @override
     @classmethod
     def decode(cls, data: bytes) -> "ZeroTerminatedStringAttribute":
         attr = cls((data[0 : len(data)]).decode("ascii"))
         return attr
 
+    @override
     def encode(self) -> bytes:
         return bytes(self.value, "ascii")
 
+    @override
     def formatted_value(self) -> str | None:
         return self.value
 
@@ -85,6 +90,7 @@ CT = TypeVar("CT", bound="ComplexTypeAttribute")
 class ComplexTypeAttribute(Attribute, ABC):
     value: t.ComplexType
 
+    @override
     @classmethod
     def decode(cls: type[CT], data: bytes) -> CT:
         value_type = cls.__annotations__["value"]
@@ -93,9 +99,11 @@ class ComplexTypeAttribute(Attribute, ABC):
         attr = cls(value_type.decode(data))
         return attr
 
+    @override
     def encode(self) -> bytes:
         return self.value.encode()
 
+    @override
     def formatted_value(self) -> str | None:
         return str(self.value)
 
@@ -106,6 +114,7 @@ class SerialNoAttribute(Attribute):
     attribute_id = 0x01
     value: int
 
+    @override
     def formatted_value(self) -> str | None:
         return self.value.to_bytes(8, "big", signed=True).hex().upper() if self.value else None
 
@@ -115,6 +124,7 @@ class FirmwareVersionAttribute(Attribute):
     attribute_id = 0x02
     value: int
 
+    @override
     @classmethod
     def decode(cls, data: bytes) -> "FirmwareVersionAttribute":
         if len(data) < cls.length():
@@ -124,13 +134,16 @@ class FirmwareVersionAttribute(Attribute):
             )
         return FirmwareVersionAttribute(int.from_bytes(data[0:3], byteorder="big", signed=False))
 
+    @override
     def encode(self) -> bytes:
         return int.to_bytes(self.value, length=3, byteorder="big", signed=True)
 
+    @override
     @classmethod
     def length(cls) -> int:
         return 3
 
+    @override
     def formatted_value(self) -> str | None:
         newval = (self.value & 0xFFFFF).to_bytes(3, "big", signed=True)
         return ".".join(str(newval[i]).zfill(2) for i in range(0, len(newval), 1))
@@ -142,6 +155,7 @@ class BluetoothMacAttribute(Attribute):
     attribute_id = 0x03
     value: int
 
+    @override
     def formatted_value(self) -> str | None:
         return self.value.to_bytes(8, "big", signed=True).hex() if self.value else None
 
@@ -169,6 +183,7 @@ class AfeSettingsAllAttribute(ComplexTypeAttribute):
     attribute_id = 0x07
     value: t.AfeSettingsAll
 
+    @override
     @classmethod
     def decode(cls, data: bytes) -> "AfeSettingsAllAttribute":
         """Special handling. certain versions of the device returns an empty attribute value."""
@@ -197,6 +212,7 @@ class SystemStatusNamesAttribute(Attribute):
     attribute_id = 0x08
     value: list[str]
 
+    @override
     @classmethod
     def decode(cls, data: bytes) -> "SystemStatusNamesAttribute":
         if len(data) == 0:
@@ -204,6 +220,7 @@ class SystemStatusNamesAttribute(Attribute):
         string = data.decode("utf-8")
         return SystemStatusNamesAttribute(value=string.split(","))
 
+    @override
     def encode(self) -> bytes:
         body = b""
         for n in self.value[:-1]:
@@ -217,12 +234,14 @@ class SystemStatusAttribute(ComplexTypeAttribute):
     attribute_id = 0xC3
     value: t.SystemStatus
 
+    @override
     @classmethod
     def decode(cls, data: bytes) -> "SystemStatusAttribute":
         if len(data) == 0:
             return SystemStatusAttribute(value=t.SystemStatus(status=[], worst=[]))
         return SystemStatusAttribute(value=t.SystemStatus.decode(data))
 
+    @override
     def encode(self) -> bytes:
         return self.value.encode()
 
@@ -236,6 +255,7 @@ class CurrentTimeAttribute(Attribute):
     def get_datetime(self) -> datetime:
         return datetime.fromtimestamp(self.value / 1000, tz=UTC)
 
+    @override
     def formatted_value(self) -> str | None:
         return self.get_datetime().replace(microsecond=0).isoformat()
 
@@ -396,6 +416,7 @@ class TemperatureAttribute(Attribute):
     def temp_celsius(self) -> float:
         return self.value * TEMPERATURE_SCALE_FACTOR
 
+    @override
     def formatted_value(self) -> str | None:
         return str(self.temp_celsius())
 
@@ -460,6 +481,7 @@ class LedsAttribute(Attribute):
     def led3_blinking(self) -> bool:
         return bool(self.value & 0b100000)
 
+    @override
     def formatted_value(self) -> str | None:
         if not self.value:
             return None

--- a/src/embodycodec/codec.py
+++ b/src/embodycodec/codec.py
@@ -14,6 +14,7 @@ from abc import ABC
 from dataclasses import astuple
 from dataclasses import dataclass
 from typing import TypeVar
+from typing import override
 
 from embodycodec import attributes as a
 from embodycodec import types as t
@@ -168,6 +169,7 @@ class SetAttribute(Message):
     attribute_id: int
     value: a.Attribute
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "SetAttribute":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -182,6 +184,7 @@ class SetAttribute(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">B", self.attribute_id)
         length_part = struct.pack(">B", self.value.length())
@@ -209,6 +212,7 @@ class GetAttributeResponse(Message):
     reporting: t.Reporting
     value: a.Attribute
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "GetAttributeResponse":
         crc, data_length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -229,6 +233,7 @@ class GetAttributeResponse(Message):
         msg.length = data_length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">BQ", self.attribute_id, self.changed_at)
         reporting_part = self.reporting.encode()
@@ -261,6 +266,7 @@ class ConfigureReporting(Message):
     attribute_id: int
     reporting: t.Reporting
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "ConfigureReporting":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -272,6 +278,7 @@ class ConfigureReporting(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">B", self.attribute_id)
         reporting_part = self.reporting.encode()
@@ -282,6 +289,7 @@ class ConfigureReporting(Message):
 class ConfigureReportingResponse(Message):
     msg_type = 0x94
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "ConfigureReportingResponse":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -308,6 +316,7 @@ class PeriodicRecording(Message):
     msg_type = 0x16
     recording: t.Recording
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "PeriodicRecording":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -318,6 +327,7 @@ class PeriodicRecording(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         return self.recording.encode()
 
@@ -334,6 +344,7 @@ class AttributeChanged(Message):
     attribute_id: int
     value: a.Attribute
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "AttributeChanged":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -347,6 +358,7 @@ class AttributeChanged(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">QB", self.changed_at, self.attribute_id)
         attribute_part = self.value.encode()
@@ -365,6 +377,7 @@ class RawPulseChanged(Message):
     changed_at: int
     value: t.PulseRawAll | t.PulseRaw
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "RawPulseChanged":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -373,7 +386,7 @@ class RawPulseChanged(Message):
         (changed_at,) = struct.unpack(">H", data[pos + 0 : pos + 2])
         # Determine if payload contains 1 or 3 PPGs
         if length - header_crc == t.PulseRawAll.default_length():
-            value = t.PulseRawAll.decode(data[pos + 2 :])  # type: Union[t.PulseRawAll, t.PulseRaw]
+            value = t.PulseRawAll.decode(data[pos + 2 :])  # type: t.PulseRawAll | t.PulseRaw
         else:
             value = t.PulseRaw.decode(data[pos + 2 :])
         msg = RawPulseChanged(changed_at=changed_at, value=value)
@@ -381,6 +394,7 @@ class RawPulseChanged(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">H", self.changed_at)
         raw_pulse_part = self.value.encode()
@@ -398,6 +412,7 @@ class RawPulseListChanged(Message):
     attribute_id: int
     value: a.PulseRawListAttribute
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "RawPulseListChanged":
         (crc, length) = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -409,6 +424,7 @@ class RawPulseListChanged(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">B", self.attribute_id)
         raw_pulse_part = self.value.encode()
@@ -450,6 +466,7 @@ class ListFilesResponse(Message):
     msg_type = 0xC1
     files: list[t.FileWithLength]
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "ListFilesResponse":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -465,6 +482,7 @@ class ListFilesResponse(Message):
                 pos += t.FileWithLength.default_length()
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         body = b""
         if self.files is None or len(self.files) == 0:
@@ -484,6 +502,7 @@ class FileDataChunk(Message):
     offset: int = 0
     file_data: bytes = b""
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "FileDataChunk":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -499,6 +518,7 @@ class FileDataChunk(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         data_hdr = struct.pack(self.struct_format, self.fileref, self.offset)
         return data_hdr + self.file_data
@@ -509,6 +529,7 @@ class GetFile(Message):
     msg_type = 0x42
     file: t.File
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "GetFile":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -519,6 +540,7 @@ class GetFile(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         return self.file.encode()
 
@@ -536,6 +558,7 @@ class SendFile(Message):
     total_parts: int
     payload: bytes
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "SendFile":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -555,6 +578,7 @@ class SendFile(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         body = self.file_name.encode()
         body += struct.pack(">H", self.index)
@@ -575,6 +599,7 @@ class DeleteFile(Message):
     msg_type = 0x44
     file: t.File
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "DeleteFile":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -585,6 +610,7 @@ class DeleteFile(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         return self.file.encode()
 
@@ -599,6 +625,7 @@ class GetFileUart(Message):
     msg_type = 0x45
     file: t.File
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "GetFileUart":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -609,6 +636,7 @@ class GetFileUart(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         return self.file.encode()
 
@@ -663,6 +691,7 @@ class ExecuteCommand(Message):
     def command_message(self) -> str | None:
         return self.command_types.get(self.command_id)
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "ExecuteCommand":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -675,6 +704,7 @@ class ExecuteCommand(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         if self.command_id == t.ExecuteCommandType.PRESS_BUTTON.value:
             attribute_part = struct.pack(">B", self.command_id)
@@ -769,6 +799,7 @@ class ExecuteCommandResponse(Message):
     response_code: int
     value: bytes | None
 
+    @override
     @classmethod
     def decode(cls, data: bytes, accept_crc_error: bool = False) -> "ExecuteCommandResponse":
         crc, length = cls._check_crc_and_get_metadata(data, accept_crc_error)
@@ -781,6 +812,7 @@ class ExecuteCommandResponse(Message):
         msg.length = length
         return msg
 
+    @override
     def _encode_body(self) -> bytes:
         if self.response_code == t.ExecuteCommandType.AFE_READ_ALL_REGISTERS.value:
             attribute_part = struct.pack(">B", self.response_code)

--- a/src/embodycodec/exceptions.py
+++ b/src/embodycodec/exceptions.py
@@ -4,14 +4,6 @@
 class DecodeError(Exception):
     """Exception when decoding message."""
 
-    pass
-
-    ...
-
 
 class CrcError(Exception):
     """Error when invalid crc is received for message from device."""
-
-    pass
-
-    ...

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -10,6 +10,8 @@ Temperature conversions use the TEMPERATURE_SCALE_FACTOR constant (0.0078125 = 1
 
 import struct
 from dataclasses import dataclass
+from typing import override
+
 
 # Temperature sensor conversion factor (degrees Celsius per raw unit)
 # This factor converts raw sensor values to degrees Celsius
@@ -39,6 +41,7 @@ class ProtocolMessage:
 class TimetickedMessage(ProtocolMessage):
     two_lsb_of_timestamp = None  # Dataclass workaround. Not specified with type to avoid having it as a dataclass field
 
+    @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < cls.default_length(version):
@@ -112,10 +115,12 @@ class PpgRaw(TimetickedMessage):
     ecg: int
     ppg: int
 
+    @override
     @classmethod
     def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
         return 8
 
+    @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < cls.default_length(version):
@@ -135,10 +140,12 @@ class PpgRawAll(TimetickedMessage):
     ppg_red: int
     ppg_ir: int
 
+    @override
     @classmethod
     def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
         return 11
 
+    @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < cls.default_length(version):
@@ -240,14 +247,17 @@ class PulseRawList(TimetickedMessage):
     ppgs: list[int]
     len: int = 6  # actual length, since this is instance specific, not static
 
+    @override
     @classmethod
     def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
         """Return a dummy value, since this is instance specific for this class."""
         return 6
 
+    @override
     def length(self, version: tuple[int, int, int] | None = None) -> int:
         return self.len
 
+    @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < 3:
@@ -297,14 +307,17 @@ class PulseBlockEcg(TimetickedMessage):
     samples: list[int]
     pkg_length: int
 
+    @override
     @classmethod
     def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
         """Return a dummy value, since this is instance specific for this class."""
         return 14
 
+    @override
     def length(self, version: tuple[int, int, int] | None = None) -> int:
         return self.pkg_length
 
+    @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None) -> "PulseBlockEcg":
         if len(data) < 14:
@@ -345,14 +358,17 @@ class PulseBlockPpg(TimetickedMessage):
     samples: list[int]
     pkg_length: int
 
+    @override
     @classmethod
     def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
         """Return a dummy value, since this is instance specific for this class."""
         return 14
 
+    @override
     def length(self, version: tuple[int, int, int] | None = None) -> int:
         return self.pkg_length
 
+    @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None) -> "PulseBlockPpg":
         if len(data) < 13:
@@ -400,10 +416,12 @@ class BatteryDiagnostics(TimetickedMessage):
     repsoc: int  # % *100  (0-100.00 %) Reported State Of Charge (Combined and final result)
     vfsoc: int  # % *100  (0-100.00 %) Voltage based fuelgauge State Of Charge
 
+    @override
     @classmethod
     def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
         return struct.calcsize(cls.struct_format)
 
+    @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < cls.default_length(version):

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -6,6 +6,7 @@ from abc import ABC
 from dataclasses import astuple
 from dataclasses import dataclass
 from typing import TypeVar
+from typing import override
 
 
 class ExecuteCommandType(enum.Enum):
@@ -106,9 +107,11 @@ class PulseRawList(ComplexType):
     ppgs: list[int]
     len = 0
 
+    @override
     def length(self) -> int:
         return self.len
 
+    @override
     @classmethod
     def decode(cls, data: bytes) -> "PulseRawList":
         if len(data) < 10:
@@ -139,6 +142,7 @@ class PulseRawList(ComplexType):
         msg.len = 1 + (no_of_ecgs * bytes_per_ecg_and_ppg) + (no_of_ppgs * bytes_per_ecg_and_ppg)
         return msg
 
+    @override
     def encode(self) -> bytes:
         format_and_length = PulseRawList.from_format_and_lengths(self.format, self.no_of_ecgs, self.no_of_ppgs)
         bytes_per_ecg_and_ppg = 1 if self.format == 0 else 2 if self.format == 1 else 3 if self.format == 2 else 4
@@ -182,6 +186,7 @@ class SystemStatus(ComplexType):
     status: list[SystemStatusType]
     worst: list[SystemStatusType]
 
+    @override
     @classmethod
     def decode(cls, data: bytes) -> "SystemStatus":
         if len(data) < 1:
@@ -196,6 +201,7 @@ class SystemStatus(ComplexType):
             worst=worst,
         )
 
+    @override
     def encode(self) -> bytes:
         payload = b""
         for n in range(len(self.status)):
@@ -332,6 +338,7 @@ class File(ComplexType):
     struct_format = ">26s"
     file_name: str | bytes
 
+    @override
     @classmethod
     def decode(cls: type[F], data: bytes) -> F:
         msg = cls(*(struct.unpack(cls.struct_format, data[0 : cls.default_length()])))
@@ -339,6 +346,7 @@ class File(ComplexType):
             msg.file_name = msg.file_name.split(b"\x00", maxsplit=1)[0].decode("utf-8")
         return msg
 
+    @override
     def encode(self) -> bytes:
         return struct.pack(self.struct_format, str(self.file_name).encode("utf-8"))
 
@@ -348,5 +356,6 @@ class FileWithLength(File):
     struct_format = File.struct_format + "I"
     file_size: int
 
+    @override
     def encode(self) -> bytes:
         return struct.pack(self.struct_format, str(self.file_name).encode("utf-8"), self.file_size)

--- a/tests/test_execute_command.py
+++ b/tests/test_execute_command.py
@@ -1,6 +1,7 @@
 """Test ExecuteCommand and ExecuteCommandResponse edge cases."""
 
 import pytest
+
 from embodycodec import codec
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 skipsdist = true
-envlist = py311, py312, py313
+envlist = py312, py313
 
 [gh-actions]
 python =
-    3.12: py311
     3.12: py312
     3.13: py313
 

--- a/uv.lock
+++ b/uv.lock
@@ -22,11 +22,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
 ]
 
 [[package]]
@@ -56,20 +56,20 @@ dev = [
 
 [[package]]
 name = "filelock"
-version = "3.20.3"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
 name = "identify"
-version = "2.6.15"
+version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -83,29 +83,29 @@ wheels = [
 
 [[package]]
 name = "nodeenv"
-version = "1.9.1"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "platformdirs"
-version = "4.5.1"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -171,6 +171,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/12/38c1a0b1e64806780c9563e3fc9f6e472251839662587cfbe9bfaf2ae10a/python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3", size = 68455, upload-time = "2026-05-28T01:15:37.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da", size = 33217, upload-time = "2026-05-28T01:15:36.573Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -227,62 +240,11 @@ wheels = [
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.17"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.15' and platform_python_implementation == 'CPython'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/fe/b6045c782f1fd1ae317d2a6ca1884857ce5c20f59befe6ab25a8603c43a7/ruamel_yaml-0.18.17-py3-none-any.whl", hash = "sha256:9c8ba9eb3e793efdf924b60d521820869d5bf0cb9c6f1b82d82de8295e290b9d", size = 121594, upload-time = "2025-12-17T20:02:07.657Z" },
-]
-
-[[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/80/8ce7b9af532aa94dd83360f01ce4716264db73de6bc8efd22c32341f6658/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c583229f336682b7212a43d2fa32c30e643d3076178fb9f7a6a14dde85a2d8bd", size = 147998, upload-time = "2025-11-16T16:13:13.241Z" },
-    { url = "https://files.pythonhosted.org/packages/53/09/de9d3f6b6701ced5f276d082ad0f980edf08ca67114523d1b9264cd5e2e0/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137", size = 132743, upload-time = "2025-11-16T16:13:14.265Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/f7/73a9b517571e214fe5c246698ff3ed232f1ef863c8ae1667486625ec688a/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5fea0932358e18293407feb921d4f4457db837b67ec1837f87074667449f9401", size = 731459, upload-time = "2025-11-16T20:22:44.338Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/a2/0dc0013169800f1c331a6f55b1282c1f4492a6d32660a0cf7b89e6684919/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71831bd61fbdb7aa0399d5c4da06bea37107ab5c79ff884cc07f2450910262", size = 749289, upload-time = "2025-11-16T16:13:15.633Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ed/3fb20a1a96b8dc645d88c4072df481fe06e0289e4d528ebbdcc044ebc8b3/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:617d35dc765715fa86f8c3ccdae1e4229055832c452d4ec20856136acc75053f", size = 777630, upload-time = "2025-11-16T16:13:16.898Z" },
-    { url = "https://files.pythonhosted.org/packages/60/50/6842f4628bc98b7aa4733ab2378346e1441e150935ad3b9f3c3c429d9408/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b45498cc81a4724a2d42273d6cfc243c0547ad7c6b87b4f774cb7bcc131c98d", size = 744368, upload-time = "2025-11-16T16:13:18.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b0/128ae8e19a7d794c2e36130a72b3bb650ce1dd13fb7def6cf10656437dcf/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:def5663361f6771b18646620fca12968aae730132e104688766cf8a3b1d65922", size = 745233, upload-time = "2025-11-16T20:22:45.833Z" },
-    { url = "https://files.pythonhosted.org/packages/75/05/91130633602d6ba7ce3e07f8fc865b40d2a09efd4751c740df89eed5caf9/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:014181cdec565c8745b7cbc4de3bf2cc8ced05183d986e6d1200168e5bb59490", size = 770963, upload-time = "2025-11-16T16:13:19.344Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/4b/fd4542e7f33d7d1bc64cc9ac9ba574ce8cf145569d21f5f20133336cdc8c/ruamel_yaml_clib-0.2.15-cp311-cp311-win32.whl", hash = "sha256:d290eda8f6ada19e1771b54e5706b8f9807e6bb08e873900d5ba114ced13e02c", size = 102640, upload-time = "2025-11-16T16:13:20.498Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/eb/00ff6032c19c7537371e3119287999570867a0eafb0154fccc80e74bf57a/ruamel_yaml_clib-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:bdc06ad71173b915167702f55d0f3f027fc61abd975bd308a0968c02db4a4c3e", size = 121996, upload-time = "2025-11-16T16:13:21.855Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4b/5fde11a0722d676e469d3d6f78c6a17591b9c7e0072ca359801c4bd17eee/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb15a2e2a90c8475df45c0949793af1ff413acfb0a716b8b94e488ea95ce7cff", size = 149088, upload-time = "2025-11-16T16:13:22.836Z" },
-    { url = "https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2", size = 134553, upload-time = "2025-11-16T16:13:24.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/cb/22366d68b280e281a932403b76da7a988108287adff2bfa5ce881200107a/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f6d3655e95a80325b84c4e14c080b2470fe4f33b6846f288379ce36154993fb1", size = 737468, upload-time = "2025-11-16T20:22:47.335Z" },
-    { url = "https://files.pythonhosted.org/packages/71/73/81230babf8c9e33770d43ed9056f603f6f5f9665aea4177a2c30ae48e3f3/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71845d377c7a47afc6592aacfea738cc8a7e876d586dfba814501d8c53c1ba60", size = 753349, upload-time = "2025-11-16T16:13:26.269Z" },
-    { url = "https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9", size = 788211, upload-time = "2025-11-16T16:13:27.441Z" },
-    { url = "https://files.pythonhosted.org/packages/30/93/e79bd9cbecc3267499d9ead919bd61f7ddf55d793fb5ef2b1d7d92444f35/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b293a37dc97e2b1e8a1aec62792d1e52027087c8eea4fc7b5abd2bdafdd6642", size = 743203, upload-time = "2025-11-16T16:13:28.671Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/06/1eb640065c3a27ce92d76157f8efddb184bd484ed2639b712396a20d6dce/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512571ad41bba04eac7268fe33f7f4742210ca26a81fe0c75357fa682636c690", size = 747292, upload-time = "2025-11-16T20:22:48.584Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
-    { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
-    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
-    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
-    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
-    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]
@@ -312,39 +274,40 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.40"
+version = "0.0.42"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/f8/a754c96967b71de8723f88be17df8738216bd382ffed229cd500b7a24d13/ty-0.0.40.tar.gz", hash = "sha256:883b53dd98f6e5b33ab1c8e1a3cd94b0f29c762ef22cdf1e86aaffb4fd711c67", size = 5726484, upload-time = "2026-05-27T17:55:43.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/91/5b5ec4ed8721c18be8d9611778d7c07723cd755676f03b41bf0ea0caa5d3/ty-0.0.42.tar.gz", hash = "sha256:70f5553ac678fc63558d4d77b08a18a68a228f44be2a2fe1afc3f5988db662e7", size = 5769116, upload-time = "2026-06-01T19:40:32.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/42/d029a72165ad39f95228b67355927fbd35c821dc8e3e475d49f47c2eeb1e/ty-0.0.40-py3-none-linux_armv6l.whl", hash = "sha256:9defb4742450e569a6a09de286a04008d6c2e815112da4362c88b6eaa2f52a36", size = 11406372, upload-time = "2026-05-27T17:55:49.633Z" },
-    { url = "https://files.pythonhosted.org/packages/23/99/7f8ea09b7e49afbf795cb3341a3217f30f228db7e62a2268ed8cbbf813d6/ty-0.0.40-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:868258a3330db88b683fcafe2c4e936d6226a6312799bf15b585d93557b2d38c", size = 11159782, upload-time = "2026-05-27T17:55:47.405Z" },
-    { url = "https://files.pythonhosted.org/packages/04/d8/1ea745ee97a98b26ae9564d19a430a76a35297cd450e84dcaad22e1f7ee8/ty-0.0.40-py3-none-macosx_11_0_arm64.whl", hash = "sha256:589c81060cf1e7a9ffa2f45bfa35ffd9b9fbd214104e3f13959f113627efcd91", size = 10594139, upload-time = "2026-05-27T17:55:37.206Z" },
-    { url = "https://files.pythonhosted.org/packages/39/1a/fbef21273c6617ff4715b4827ee1c0b6550aa7d1df4b8c43b325545c1cf4/ty-0.0.40-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b06108990cb338d941c315ae6e9ba2fff8f518bc15d3f33e5619ff6a6c9beab", size = 11114156, upload-time = "2026-05-27T17:55:56.11Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f9/389fc4976d7ec016a7473cf1274bf9c4f491bb54c66649bd022bff9f2b6a/ty-0.0.40-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3913ef37336bec4f96bd2512f8c3a543ca34c259b7170f7eb5adf75b3ed7f04c", size = 11189050, upload-time = "2026-05-27T17:55:54.099Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a9/4ecabbf4bdda7df0d99d8d3892c6edac0efc8c4cae756a5109178a3d0e86/ty-0.0.40-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fd1486bd5fe48779a8aa857137f3642a0a9161f5cf57d4380f4a0ecea01c8f3", size = 11664266, upload-time = "2026-05-27T17:55:28.17Z" },
-    { url = "https://files.pythonhosted.org/packages/45/02/0aa78730116507c265afb1d6d5961c583b49d4c2e368c4a49fd81bcae6dc/ty-0.0.40-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1668364d5254a734329917ee66c2c5fdd5665389d41043f6fce0f22ddb32b749", size = 12187743, upload-time = "2026-05-27T17:56:04.337Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/68/ccabf2d173523598271a385c1d3f864dbda23e5ebdc67f5969b9e830ea05/ty-0.0.40-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:43f77a73edb91e5dfa2ab9af7c4cac64614f8cc121f38a8875f22e830d3aba6a", size = 11862999, upload-time = "2026-05-27T17:55:58.087Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8d/6d7ec22771bb23d534797cdb446eb644bccfe7a62b729bb99e7235a02fc3/ty-0.0.40-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1274ce0212ecbfed01bda7c3659c46e8bd0068e32d00c46c790466a95274c3df", size = 11743896, upload-time = "2026-05-27T17:56:00.017Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/a4/f9fa076b010c91cb249b1fcc3476569b7b8462cb4b688da2d04c23a0622f/ty-0.0.40-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5ee1261dbc363e5cc1a0c5bb0c8612c192bfe53491214df8bc85a540835685f9", size = 11883581, upload-time = "2026-05-27T17:56:02.319Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/0f/5b776a2328c756d574dd4d6afbd30fc24e1ab4b76935c7c3c23f27ebbcb9/ty-0.0.40-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6220e2cd5cdc4683dd87fb150d195bbd9f1a021395e04cb08bd3c66ea6da6ef8", size = 11093946, upload-time = "2026-05-27T17:55:33.284Z" },
-    { url = "https://files.pythonhosted.org/packages/64/c4/eb23154bae83ad7c2935e9e5916660fb3e31598a92ee232aebd79410480c/ty-0.0.40-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:46b9ed69d01d98ef046afac9983c68336f572605ea2a27b90fbe6f80bfc8d6b7", size = 11210737, upload-time = "2026-05-27T17:55:45.523Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/19/1fb2529703f708cacfd13a89f98613cae2907dfa941b26976467e6119803/ty-0.0.40-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ddbca9fab4406260f141674ab5efcfe7b02bd468e6985e4cdde0a21626e69ffe", size = 11332563, upload-time = "2026-05-27T17:55:41.674Z" },
-    { url = "https://files.pythonhosted.org/packages/87/69/b3f5a8ef26c31204e0391147b3adcdb0674eda3e7d99868478ef168a41c6/ty-0.0.40-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1fcc082a749e6dc11b68fe9aab0420238bbf2a2374c2c7aa3c22e8c1618b136", size = 11843216, upload-time = "2026-05-27T17:55:35.367Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/e8/20193069d32787f3e1a6ec8940aaa3759d3de8f48f9281bcc0c5cb0939da/ty-0.0.40-py3-none-win32.whl", hash = "sha256:75feb115b3587824c5bdf8f8305e9547b0d1e398e3077b0addc7a1988ea9bb50", size = 10670731, upload-time = "2026-05-27T17:55:31.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/f9/8b2aa4da61db81322d4a2f9db227afeb48110ca15ae31d380f64c64ceb63/ty-0.0.40-py3-none-win_amd64.whl", hash = "sha256:b0f905edaad788bd61f779a85801b60a267a25ed57fca05aaddd168d9d8896be", size = 11766211, upload-time = "2026-05-27T17:55:51.898Z" },
-    { url = "https://files.pythonhosted.org/packages/04/87/369056ed46f1b235130ec0595393262f9cd2061ca3dab276d490980f9343/ty-0.0.40-py3-none-win_arm64.whl", hash = "sha256:07da2b09d9130e2c9a257d2a29beb53105835b0256ee5fdb288fe1aab83fee47", size = 11117369, upload-time = "2026-05-27T17:55:39.329Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/7c/2df5136ad7c0db69a3973b0b19da8f52bfacdc453c7dffc832d1bf7d23ff/ty-0.0.42-py3-none-linux_armv6l.whl", hash = "sha256:c08a0066610c13627b7d7ad758adb96ca99685791e641eb26837e20803851c53", size = 11544141, upload-time = "2026-06-01T19:40:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/82/96cf406d39d8976e825361a27e332224445812793060ac9506d8a5d32b39/ty-0.0.42-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3e944ee4e3d5cdaf70e4ea87f9dd474cc3db612837b50a3ce57afa8da400ecc2", size = 11283538, upload-time = "2026-06-01T19:40:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/fe/813b60b9332df835c16c05859ff5aac1896593d01b638ba0e461ede415ac/ty-0.0.42-py3-none-macosx_11_0_arm64.whl", hash = "sha256:603085306e4aac2ce592b39119a4b49ebf8b780cd394e2cfc7dbf3fd8228f954", size = 10711874, upload-time = "2026-06-01T19:40:28.77Z" },
+    { url = "https://files.pythonhosted.org/packages/07/64/1f609265be0302ce0f51aa03a27636d018947a76100ff1405258d8445e6c/ty-0.0.42-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a58f17834d7f078c49326a01111a5aac16c979a774b98cdfd8e2350068316676", size = 11213021, upload-time = "2026-06-01T19:40:45.01Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c0/f147b2fde7cd01b5f77682937e85a5cdfe35f48b3f1d0f41021024cbd927/ty-0.0.42-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e6ed1027f313202c5c74e376007d1eb5d214494299beb0ea047078b8ad307d40", size = 11321604, upload-time = "2026-06-01T19:40:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/72/74a5e68a9bd194681f15c4aac7a0dfab378e76e7a107e8ecd93971a22377/ty-0.0.42-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:063838d2360c1d2c065b45ca76a56ecd6df07fff6570813e74183236559e16d9", size = 11802178, upload-time = "2026-06-01T19:40:19.558Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9f/06a31dc9cc91faa2cb8a4bf2f0ba5f7a9a96a4828fb8434338682954ca86/ty-0.0.42-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3f9ed508dfae4cbc943d7766324dd9c57ac8302c8543505fc29cae8ed425fe9", size = 12358436, upload-time = "2026-06-01T19:40:48.968Z" },
+    { url = "https://files.pythonhosted.org/packages/06/33/a5bb1afcb671e0b9197f007264682b22f1063bf0e83c151eeaf9958f9047/ty-0.0.42-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fe1eb7d98472ac56ac19fec51c6ed8fe56d86ea0d232a11a127e8c62c882a66", size = 11997849, upload-time = "2026-06-01T19:40:42.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8d/560e4ec4c2f69e68fa094bb93cd19b5eb92c9732d2e0f5e7cc3accde84c4/ty-0.0.42-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de75f9e78bfa81209f2f297528758977cfd4518ba35ef45a0acb516c892a27a5", size = 11869087, upload-time = "2026-06-01T19:40:24.38Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/3794db15199c03eda60961690046a56c4fbf5d8ef073c82fe2402c851b8c/ty-0.0.42-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c63281f2f1d4df339117fcd4a6dfe17cb999f84eafe707b30e9ebbe26f0bb54a", size = 12059000, upload-time = "2026-06-01T19:40:34.982Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9a/02b61cc65ecbd90f18bd02178845c5b756c78fb92643571e77df52c6eed8/ty-0.0.42-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:19e3856477f25255f772851fa7f16f5356c4e1927324d074d49c7bc9a9b211e1", size = 11195698, upload-time = "2026-06-01T19:40:37.109Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d6/3927335c956b06a806269dcd2e5b46bc4284b0a95ecc6b0246094a1de28c/ty-0.0.42-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2f0f4acac9028264cee5ea0b88229df0b9b2586fc917dbadb6ee35a0e99e8b06", size = 11353487, upload-time = "2026-06-01T19:40:47.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/87/79e7ae4f5f9fb3bea5f3cfac2b4f8c60e905f13962e3c0d97f8b51a5bff6/ty-0.0.42-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ae244c84e30fdf2bb1a3cbf2b973da8aa535e57c701f12db44b2939604586c04", size = 11463474, upload-time = "2026-06-01T19:40:30.812Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f9/73305ead1b3ccc3d79c04258877db2cd7908c6a6c2060d4e598deca384d2/ty-0.0.42-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2430434f4a52bec0da552ff6a061dcc1c5d11973259248679a1146d776c12f37", size = 11961710, upload-time = "2026-06-01T19:40:39.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/52b7325dad8d1a86653f90240208f3e3657bed5e3c8144eed367a0f736b0/ty-0.0.42-py3-none-win32.whl", hash = "sha256:984a55c2fe63b40dac03f5a144b99033c7ed720eb7611787e3f0bd49af8dcf12", size = 10783897, upload-time = "2026-06-01T19:40:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d2/3d2d61255c76c0843766f00b39290115c23cc1cd4fcb0471d84a48f482f1/ty-0.0.42-py3-none-win_amd64.whl", hash = "sha256:f7afd81b10b377d9d4ce6aad355a4f47fd37d47f443118c01ca6e79d46fe6608", size = 11878640, upload-time = "2026-06-01T19:40:50.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/91/1eb0c1e3d558707ead7424f8bfd89b58f42e576714cbed7ad46dcceef34a/ty-0.0.42-py3-none-win_arm64.whl", hash = "sha256:4068c24b0b264fc9f1901e06b97988a041fcaa36c90f18d7747f05124701c7b3", size = 11202335, upload-time = "2026-06-01T19:40:53.155Z" },
 ]
 
 [[package]]
 name = "virtualenv"
-version = "20.36.1"
+version = "21.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <4.0"
+requires-python = ">=3.12, <4.0"
 
 [[package]]
 name = "cfgv"
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "embody-codec"
-version = "1.0.39"
+version = "1.0.40"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -50,8 +50,8 @@ dev = [
     { name = "pre-commit", specifier = ">=2.16.0" },
     { name = "pre-commit-hooks", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=7.2.0" },
-    { name = "ruff", specifier = ">=0.11.5" },
-    { name = "ty", specifier = ">=0.0.2" },
+    { name = "ruff", specifier = ">=0.15.15" },
+    { name = "ty", specifier = ">=0.0.42" },
 ]
 
 [[package]]
@@ -189,15 +189,6 @@ version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
     { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
     { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
     { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },


### PR DESCRIPTION
## Summary

Maintenance release bumping the package to **1.0.40**. The codebase was already clean (ruff + ty passing, zero suppression comments), so this release focuses on tooling/config drift and sharpening lint/type rules to enforce more best practices.

## Changes

### Version & Python support
- `1.0.39` → `1.0.40`
- **Drop Python 3.11** → `requires-python = ">=3.12,<4.0"`. Updated ruff `target-version`, ty `python-version`, CI matrix (`[3.12, 3.13]`), `tox.ini`, README, and CONTRIBUTING.

### Sharpened ruff
- Removed dubious ignores: `F401` and `PTH123` (0 violations — now enforced) and `I001` (import sorting now enforced).
- Added `PIE` rule family.
- Migrated the vestigial `[tool.isort]` block into `[tool.ruff.lint.isort]` (`force-single-line`, `lines-after-imports = 2`), preserving the one-import-per-line style, then deleted `[tool.isort]`.

### Sharpened ty
- `error-on-warning = true` (locks in `deprecated` / `redundant-cast`).
- `missing-override-decorator = "error"` — added `@override` to all **75** overriding methods across `codec.py`, `attributes.py`, `file_codec.py`, `types.py`. Enabled by moving to `typing.override` (3.12 stdlib, **no new runtime dependency** — the zero-dependency property is preserved).

### Cleanups & version sync
- Removed redundant `pass`/`...` placeholders in `exceptions.py`.
- Modernized a legacy `# type: Union[...]` comment in `codec.py`.
- Fixed the `tox.ini` `[gh-actions]` duplicate-key bug (`3.12: py311`).
- Bumped pre-commit ruff hook `v0.11.5` → `v0.15.15`; raised dev-dep floors to `ruff>=0.15.15`, `ty>=0.0.42`.

## Verification
- `ruff check .` — clean
- `ruff format --check .` — clean
- `ty check .` and `ty check src --error all` — clean
- `uv lock --locked` — consistent
- `make check` (lock + pre-commit + ty) — passed
- `pytest` — **140 passed**

## Deliberately out of scope
Docstring rules, `SIM`/`RET` families, coverage `fail_under`, and dataclass `slots=True` — each is high-churn or a behavior/perf change rather than a compliance fix.