### PR TITLE
fix: correct variable-length payload encoding on the wire

### DIFF
--- a/src/embodycodec/attributes.py
+++ b/src/embodycodec/attributes.py
@@ -43,6 +43,12 @@ class Attribute(ABC):
 
     @classmethod
     def length(cls) -> int:
+        """Static size of this attribute in bytes.
+
+        Only meaningful for fixed-size attributes. Subclasses with a variable-size
+        payload leave `struct_format` empty and so report 0 here — use
+        `len(instance.encode())` when the real encoded size is needed.
+        """
         return struct.calcsize(cls.struct_format)
 
     @classmethod
@@ -136,7 +142,9 @@ class FirmwareVersionAttribute(Attribute):
 
     @override
     def encode(self) -> bytes:
-        return int.to_bytes(self.value, length=3, byteorder="big", signed=True)
+        # signed=False to match decode(). With signed=True this raised OverflowError for
+        # any version >= 0x800000, i.e. major version 128 and up.
+        return int.to_bytes(self.value, length=3, byteorder="big", signed=False)
 
     @override
     @classmethod
@@ -145,7 +153,9 @@ class FirmwareVersionAttribute(Attribute):
 
     @override
     def formatted_value(self) -> str | None:
-        newval = (self.value & 0xFFFFF).to_bytes(3, "big", signed=True)
+        # 0xFFFFFF, not 0xFFFFF: the value is three bytes (24 bits), and the 20-bit mask
+        # silently truncated the major version.
+        newval = (self.value & 0xFFFFFF).to_bytes(3, "big", signed=False)
         return ".".join(str(newval[i]).zfill(2) for i in range(0, len(newval), 1))
 
 
@@ -222,11 +232,9 @@ class SystemStatusNamesAttribute(Attribute):
 
     @override
     def encode(self) -> bytes:
-        body = b""
-        for n in self.value[:-1]:
-            body += bytes(n, "ascii") + b","
-        body += bytes(self.value[-1], "ascii")
-        return body
+        # join, not value[-1]: decode(b"") yields an empty list, and indexing it raised
+        # IndexError on the empty round-trip.
+        return b",".join(bytes(n, "ascii") for n in self.value)
 
 
 @dataclass

--- a/src/embodycodec/codec.py
+++ b/src/embodycodec/codec.py
@@ -26,6 +26,23 @@ from embodycodec.exceptions import DecodeError
 T = TypeVar("T", bound="Message")
 AT = TypeVar("AT", bound="a.Attribute")
 
+MAX_ATTRIBUTE_LENGTH = 0xFF
+"""The attribute length field is a single unsigned byte."""
+
+
+def _encode_attribute_length(attribute_part: bytes) -> bytes:
+    """Pack the one-byte attribute length, refusing payloads that do not fit.
+
+    Without the check, struct raises a bare `struct.error` mentioning only the format
+    character, which says nothing about which attribute was too large.
+    """
+    if len(attribute_part) > MAX_ATTRIBUTE_LENGTH:
+        raise ValueError(
+            f"Attribute payload is {len(attribute_part)} bytes, but the protocol length "
+            f"field holds at most {MAX_ATTRIBUTE_LENGTH}"
+        )
+    return struct.pack(">B", len(attribute_part))
+
 
 @dataclass
 class Message(ABC):
@@ -186,10 +203,11 @@ class SetAttribute(Message):
 
     @override
     def _encode_body(self) -> bytes:
-        first_part_of_body = struct.pack(">B", self.attribute_id)
-        length_part = struct.pack(">B", self.value.length())
+        # The length must come from the encoded bytes, not from Attribute.length(),
+        # which is a classmethod over struct_format and therefore reports 0 for every
+        # variable-length attribute (strings, system status, pulse raw lists).
         attribute_part = self.value.encode()
-        return first_part_of_body + length_part + attribute_part
+        return struct.pack(">B", self.attribute_id) + _encode_attribute_length(attribute_part) + attribute_part
 
 
 @dataclass
@@ -238,8 +256,7 @@ class GetAttributeResponse(Message):
         first_part_of_body = struct.pack(">BQ", self.attribute_id, self.changed_at)
         reporting_part = self.reporting.encode()
         attribute_part = self.value.encode()
-        length_part = struct.pack(">B", len(attribute_part))
-        return first_part_of_body + reporting_part + length_part + attribute_part
+        return first_part_of_body + reporting_part + _encode_attribute_length(attribute_part) + attribute_part
 
     def value_as(self, attr_type: type[AT]) -> AT:
         """Type-safe accessor for the attribute value with runtime type checking."""
@@ -362,8 +379,7 @@ class AttributeChanged(Message):
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">QB", self.changed_at, self.attribute_id)
         attribute_part = self.value.encode()
-        length_part = struct.pack(">B", len(attribute_part))
-        return first_part_of_body + length_part + attribute_part
+        return first_part_of_body + _encode_attribute_length(attribute_part) + attribute_part
 
 
 @dataclass
@@ -441,12 +457,12 @@ class Alarm(Message):
     struct_format = ">QB"
     alarm_types = {0x01: "Low battery", 0x02: "Device off body", 0x03: "Device error"}
     msg_type = 0x31
-    changed_at: int | None
-    alarm_type: int | None
+    # Not optional: struct_format ">QB" cannot pack None, so an Alarm holding None
+    # raises struct.error on encode(). The annotation must not promise otherwise.
+    changed_at: int
+    alarm_type: int
 
     def alarm_message(self) -> str | None:
-        if self.alarm_type is None:
-            return None
         return self.alarm_types.get(self.alarm_type)
 
 
@@ -591,7 +607,14 @@ class SendFile(Message):
 class SendFileResponse(Message):
     struct_format = ">H"
     msg_type = 0xC3
-    crc: int
+
+    file_crc: int
+    """CRC of the transferred file.
+
+    Note: this must not be named `crc`. `Message.crc` holds the message footer CRC and
+    is assigned by `Message.decode` after construction, so a field of that name would be
+    overwritten with the footer value during every decode.
+    """
 
 
 @dataclass

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -17,6 +17,9 @@ from typing import override
 # This factor converts raw sensor values to degrees Celsius
 TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
 
+# channel (1B) + packed sample count (1B) + time (8B) + reference sample (4B)
+PULSE_BLOCK_HEADER_LENGTH = 14
+
 
 @dataclass
 class ProtocolMessage:
@@ -261,7 +264,7 @@ class PulseRawList(TimetickedMessage):
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < 3:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 10 bytes")
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 3 bytes")
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
         fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)
@@ -320,13 +323,16 @@ class PulseBlockEcg(TimetickedMessage):
     @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None) -> "PulseBlockEcg":
-        if len(data) < 14:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+        if len(data) < PULSE_BLOCK_HEADER_LENGTH:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least {PULSE_BLOCK_HEADER_LENGTH} bytes"
+            )
         channel = data[0]
         packed_ecgs = data[1]
-        pkg_length = 1 + 1 + 8 + 4 + (packed_ecgs * 2)
+        pkg_length = PULSE_BLOCK_HEADER_LENGTH + (packed_ecgs * 2)
         if len(data) < pkg_length:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {pkg_length} bytes")
         (time,) = struct.unpack("<Q", data[2:10])
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
@@ -346,8 +352,12 @@ class PulseBlockEcg(TimetickedMessage):
         return msg
 
     def encode(self) -> bytes:
-        payload = struct.pack("<H", 0)
-        return payload
+        # Was a stub returning b"\x00\x00" regardless of contents, which looks like a
+        # valid encoding. File-format messages are produced by the device and only ever
+        # decoded here.
+        raise NotImplementedError(
+            f"{type(self).__name__} is decode-only; file messages are not encoded by this library"
+        )
 
 
 @dataclass
@@ -371,13 +381,16 @@ class PulseBlockPpg(TimetickedMessage):
     @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None) -> "PulseBlockPpg":
-        if len(data) < 13:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+        if len(data) < PULSE_BLOCK_HEADER_LENGTH:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least {PULSE_BLOCK_HEADER_LENGTH} bytes"
+            )
         channel = data[0]
         packed_ppgs = data[1]
-        pkg_length = 1 + 1 + 8 + 4 + (packed_ppgs * 2)
+        pkg_length = PULSE_BLOCK_HEADER_LENGTH + (packed_ppgs * 2)
         if len(data) < pkg_length:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {pkg_length} bytes")
         (time,) = struct.unpack("<Q", data[2:10])
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
@@ -397,8 +410,12 @@ class PulseBlockPpg(TimetickedMessage):
         return msg
 
     def encode(self) -> bytes:
-        payload = struct.pack("<H", 0)
-        return payload
+        # Was a stub returning b"\x00\x00" regardless of contents, which looks like a
+        # valid encoding. File-format messages are produced by the device and only ever
+        # decoded here.
+        raise NotImplementedError(
+            f"{type(self).__name__} is decode-only; file messages are not encoded by this library"
+        )
 
 
 @dataclass

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -264,7 +264,10 @@ class PulseRawList(TimetickedMessage):
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < 3:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 3 bytes")
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least 3 bytes to determine the full length"
+            )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
         fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -143,7 +143,7 @@ class PulseRawList(ComplexType):
         length = cls.header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
         if len(data) < length:
             raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
-        pos = 3
+        pos = cls.header_length
         for _ in range(no_of_ecgs):
             ecg = int.from_bytes(data[pos : pos + bytes_per_ecg_and_ppg], byteorder="little", signed=True)
             ecgs.append(ecg)

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -129,7 +129,8 @@ class PulseRawList(ComplexType):
     def decode(cls, data: bytes) -> "PulseRawList":
         if len(data) < cls.header_length:
             raise BufferError(
-                f"Buffer too short for message. Received {len(data)} bytes, expected at least {cls.header_length} bytes"
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least {cls.header_length} bytes to determine the full length"
             )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -105,23 +105,43 @@ class PulseRawList(ComplexType):
     no_of_ppgs: int
     ecgs: list[int]
     ppgs: list[int]
+
+    header_length = 3
+    """tick (2 bytes, little endian) + packed format/sizes byte"""
+
     len = 0
+    """Deprecated, kept for backwards compatibility. Set by decode(); use length() instead.
+
+    Note: intentionally not a dataclass field, so it stays out of __eq__ and astuple().
+    """
+
+    @staticmethod
+    def bytes_per_sample(fmt: int) -> int:
+        """Sample width in bytes for a given wire format (0-3)."""
+        return 1 if fmt == 0 else 2 if fmt == 1 else 3 if fmt == 2 else 4
 
     @override
     def length(self) -> int:
-        return self.len
+        return self.header_length + (self.no_of_ecgs + self.no_of_ppgs) * self.bytes_per_sample(self.format)
 
     @override
     @classmethod
     def decode(cls, data: bytes) -> "PulseRawList":
-        if len(data) < 10:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 10 bytes")
+        if len(data) < cls.header_length:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, expected at least {cls.header_length} bytes"
+            )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
         fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)
         ecgs = []
         ppgs = []
-        bytes_per_ecg_and_ppg = 1 if fmt == 0 else 2 if fmt == 1 else 3 if fmt == 2 else 4
+        bytes_per_ecg_and_ppg = cls.bytes_per_sample(fmt)
+        # Without this, int.from_bytes() on short slices silently yields zeros instead
+        # of reporting that the caller needs to buffer more data.
+        length = cls.header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
+        if len(data) < length:
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
         pos = 3
         for _ in range(no_of_ecgs):
             ecg = int.from_bytes(data[pos : pos + bytes_per_ecg_and_ppg], byteorder="little", signed=True)
@@ -139,13 +159,13 @@ class PulseRawList(ComplexType):
             ecgs=ecgs,
             ppgs=ppgs,
         )
-        msg.len = 1 + (no_of_ecgs * bytes_per_ecg_and_ppg) + (no_of_ppgs * bytes_per_ecg_and_ppg)
+        msg.len = length
         return msg
 
     @override
     def encode(self) -> bytes:
         format_and_length = PulseRawList.from_format_and_lengths(self.format, self.no_of_ecgs, self.no_of_ppgs)
-        bytes_per_ecg_and_ppg = 1 if self.format == 0 else 2 if self.format == 1 else 3 if self.format == 2 else 4
+        bytes_per_ecg_and_ppg = self.bytes_per_sample(self.format)
         payload = struct.pack("<H", self.tick)
         payload += struct.pack("<B", format_and_length)
         for element in range(self.no_of_ecgs):

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -678,12 +678,14 @@ def test_send_file() -> None:
 
 
 def test_send_file_response() -> None:
-    response = codec.SendFileResponse(9)
+    response = codec.SendFileResponse(file_crc=9)
     encoded = response.encode()
     assert encoded == b"\xc3\x00\x07\x00\t\xd8\xdf"
     decoded = codec.decode(encoded)
     assert isinstance(decoded, codec.SendFileResponse)
     assert decoded.length == 7
+    assert decoded.file_crc == 9
+    assert decoded == response
 
 
 def test_delete_file() -> None:

--- a/tests/test_variable_length_payloads.py
+++ b/tests/test_variable_length_payloads.py
@@ -187,6 +187,33 @@ def test_attribute_payload_at_the_length_limit_is_accepted() -> None:
     assert decoded.value == at_limit
 
 
+@pytest.mark.parametrize("fmt", [0, 1, 2, 3])
+@pytest.mark.parametrize(("no_of_ecgs", "no_of_ppgs"), [(0, 0), (1, 1), (1, 0), (0, 1)])
+def test_pulse_raw_list_accepts_short_but_complete_message(fmt: int, no_of_ecgs: int, no_of_ppgs: int) -> None:
+    """A message can legitimately be as short as 3 bytes; the guard used to demand 10.
+
+    The smallest cases here (1-byte samples, few channels) all encode to under 10 bytes,
+    so `types.PulseRawList.decode` rejected complete, valid messages outright. The
+    `file_codec` twin already guarded on 3 - this is the other half of that drift.
+    """
+    message = types.PulseRawList(
+        tick=811,
+        format=fmt,
+        no_of_ecgs=no_of_ecgs,
+        no_of_ppgs=no_of_ppgs,
+        ecgs=[7] * no_of_ecgs,
+        ppgs=[9] * no_of_ppgs,
+    )
+    encoded = message.encode()
+    assert len(encoded) == types.PulseRawList.header_length + (no_of_ecgs + no_of_ppgs) * (fmt + 1)
+
+    assert types.PulseRawList.decode(encoded) == message
+    from_file = file_codec.PulseRawList.decode(encoded)
+    assert from_file.ecgs == message.ecgs
+    assert from_file.ppgs == message.ppgs
+    assert from_file.length() == len(encoded)
+
+
 def test_system_status_names_empty_round_trip() -> None:
     """decode(b"") yields an empty list, and encoding it raised IndexError."""
     decoded = attributes.SystemStatusNamesAttribute.decode(b"")

--- a/tests/test_variable_length_payloads.py
+++ b/tests/test_variable_length_payloads.py
@@ -1,0 +1,246 @@
+"""Regression tests for variable-length payloads.
+
+The original test suite only asserted round-trips for fixed-size payloads, which hid a
+family of defects in every attribute and complex type whose encoded size is not static.
+Each test here fails against the code as it was before these were fixed.
+"""
+
+import pytest
+
+from embodycodec import attributes
+from embodycodec import codec
+from embodycodec import file_codec
+from embodycodec import types
+
+
+VARIABLE_LENGTH_ATTRIBUTES = [
+    attributes.ModelAttribute("EMB123"),
+    attributes.VendorAttribute("Aidee"),
+    attributes.SystemStatusNamesAttribute(["cpu", "flash", "afe"]),
+    attributes.SystemStatusAttribute(
+        types.SystemStatus(
+            status=[types.SystemStatusType.OK, types.SystemStatusType.WARNING],
+            worst=[types.SystemStatusType.OK, types.SystemStatusType.FAILED],
+        )
+    ),
+    attributes.PulseRawListAttribute(
+        types.PulseRawList(
+            tick=843,
+            format=3,
+            no_of_ecgs=1,
+            no_of_ppgs=3,
+            ecgs=[1],
+            ppgs=[1000, 100, 5],
+        )
+    ),
+]
+
+
+@pytest.mark.parametrize("attribute", VARIABLE_LENGTH_ATTRIBUTES, ids=lambda a: type(a).__name__)
+def test_set_attribute_declares_real_payload_length(attribute: attributes.Attribute) -> None:
+    """SetAttribute wrote a length byte of 0 for every variable-length attribute.
+
+    The payload still went out on the wire, but the length field said zero, so a
+    conforming parser dropped the value.
+    """
+    encoded = codec.SetAttribute(attribute_id=attribute.attribute_id, value=attribute).encode()
+
+    expected_payload = attribute.encode()
+    declared_length = encoded[codec.Message.hdr_len + 1]
+    assert declared_length == len(expected_payload)
+    assert declared_length > 0
+
+    decoded = codec.decode(encoded)
+    assert isinstance(decoded, codec.SetAttribute)
+    assert decoded.value == attribute
+
+
+@pytest.mark.parametrize("attribute", VARIABLE_LENGTH_ATTRIBUTES, ids=lambda a: type(a).__name__)
+def test_get_attribute_response_round_trip(attribute: attributes.Attribute) -> None:
+    """GetAttributeResponse already derived its length correctly - guard against regression."""
+    response = codec.GetAttributeResponse(
+        attribute_id=attribute.attribute_id,
+        changed_at=1,
+        reporting=types.Reporting(interval=1, on_change=1),
+        value=attribute,
+    )
+    decoded = codec.decode(response.encode())
+    assert isinstance(decoded, codec.GetAttributeResponse)
+    assert decoded.value == attribute
+
+
+def test_send_file_response_preserves_file_crc() -> None:
+    """The payload field used to be named `crc`, colliding with Message.crc.
+
+    Message.decode assigns the footer CRC to `.crc` after construction, so the decoded
+    file CRC was silently replaced by the message CRC.
+    """
+    response = codec.SendFileResponse(file_crc=9)
+    encoded = response.encode()
+    assert encoded == b"\xc3\x00\x07\x00\t\xd8\xdf"
+
+    decoded = codec.decode(encoded)
+    assert isinstance(decoded, codec.SendFileResponse)
+    assert decoded.file_crc == 9
+    assert decoded.crc == 0xD8DF  # message footer CRC, a separate value
+    assert decoded.length == 7
+
+
+# format selects the sample width: 0 -> 1 byte, 1 -> 2, 2 -> 3, 3 -> 4.
+# to_format_and_lengths() masks ecgs to 2 bits and ppgs to 4 bits, so those are the caps.
+@pytest.mark.parametrize("fmt", [0, 1, 2, 3])
+@pytest.mark.parametrize(("no_of_ecgs", "no_of_ppgs"), [(0, 0), (1, 3), (3, 15), (0, 15), (3, 0)])
+def test_pulse_raw_list_length_matches_encoded_size(fmt: int, no_of_ecgs: int, no_of_ppgs: int) -> None:
+    """length() returned 0 on a constructed instance and under-reported by 2 after decode.
+
+    Parameterised over every sample width, since the width table is what length() and the
+    truncation check both depend on.
+    """
+    pulse_raw_list = types.PulseRawList(
+        tick=843,
+        format=fmt,
+        no_of_ecgs=no_of_ecgs,
+        no_of_ppgs=no_of_ppgs,
+        ecgs=[1] * no_of_ecgs,
+        ppgs=[1] * no_of_ppgs,
+    )
+    encoded = pulse_raw_list.encode()
+    assert pulse_raw_list.length() == len(encoded)
+
+    decoded = types.PulseRawList.decode(encoded)
+    assert decoded.length() == len(encoded)
+    assert decoded.len == len(encoded)
+    assert decoded == pulse_raw_list
+
+
+@pytest.mark.parametrize("fmt", [0, 1, 2, 3])
+def test_pulse_raw_list_rejects_truncation_for_every_sample_width(fmt: int) -> None:
+    full = types.PulseRawList(
+        tick=843,
+        format=fmt,
+        no_of_ecgs=3,
+        no_of_ppgs=15,
+        ecgs=[1, 2, 3],
+        ppgs=list(range(15)),
+    ).encode()
+
+    with pytest.raises(BufferError):
+        types.PulseRawList.decode(full[:-1])
+    with pytest.raises(BufferError):
+        file_codec.PulseRawList.decode(full[:-1])
+
+
+@pytest.mark.parametrize("truncate_to", [3, 10, 18])
+def test_pulse_raw_list_rejects_truncated_buffer(truncate_to: int) -> None:
+    """A short buffer used to yield zeroed samples instead of asking for more data.
+
+    Parameterised over both implementations so the two copies cannot drift apart again.
+    """
+    full = types.PulseRawList(
+        tick=843,
+        format=3,
+        no_of_ecgs=1,
+        no_of_ppgs=3,
+        ecgs=[1],
+        ppgs=[1000, 100, 5],
+    ).encode()
+    assert len(full) > truncate_to
+
+    with pytest.raises(BufferError):
+        types.PulseRawList.decode(full[:truncate_to])
+    with pytest.raises(BufferError):
+        file_codec.PulseRawList.decode(full[:truncate_to])
+
+
+def test_oversized_attribute_payload_is_rejected_clearly() -> None:
+    """The length field is one byte, so a >255 byte payload cannot be represented.
+
+    Deriving the real length (rather than always writing 0) exposes this; struct's own
+    error names only the format character, so raise something that names the problem.
+    """
+    oversized = attributes.SystemStatusNamesAttribute([f"sensor{i:03d}" for i in range(30)])
+    assert len(oversized.encode()) > codec.MAX_ATTRIBUTE_LENGTH
+
+    for message in (
+        codec.SetAttribute(attribute_id=oversized.attribute_id, value=oversized),
+        codec.AttributeChanged(changed_at=1, attribute_id=oversized.attribute_id, value=oversized),
+        codec.GetAttributeResponse(
+            attribute_id=oversized.attribute_id,
+            changed_at=1,
+            reporting=types.Reporting(interval=1, on_change=1),
+            value=oversized,
+        ),
+    ):
+        with pytest.raises(ValueError, match="protocol length field"):
+            message.encode()
+
+
+def test_attribute_payload_at_the_length_limit_is_accepted() -> None:
+    """Exactly 255 bytes must still encode - the check is > not >=."""
+    at_limit = attributes.ModelAttribute("x" * codec.MAX_ATTRIBUTE_LENGTH)
+    assert len(at_limit.encode()) == codec.MAX_ATTRIBUTE_LENGTH
+
+    encoded = codec.SetAttribute(attribute_id=at_limit.attribute_id, value=at_limit).encode()
+    assert encoded[codec.Message.hdr_len + 1] == codec.MAX_ATTRIBUTE_LENGTH
+    decoded = codec.decode(encoded)
+    assert isinstance(decoded, codec.SetAttribute)
+    assert decoded.value == at_limit
+
+
+def test_system_status_names_empty_round_trip() -> None:
+    """decode(b"") yields an empty list, and encoding it raised IndexError."""
+    decoded = attributes.SystemStatusNamesAttribute.decode(b"")
+    assert decoded.value == []
+    assert decoded.encode() == b""
+
+
+def test_system_status_names_round_trip() -> None:
+    attribute = attributes.SystemStatusNamesAttribute(["cpu", "flash", "afe"])
+    assert attribute.encode() == b"cpu,flash,afe"
+    assert attributes.SystemStatusNamesAttribute.decode(attribute.encode()) == attribute
+
+
+@pytest.mark.parametrize("value", [0x000000, 0x050202, 0x7FFFFF, 0x800000, 0x900000, 0xFFFFFF])
+def test_firmware_version_round_trip(value: int) -> None:
+    """encode() used signed=True while decode() used signed=False.
+
+    Anything from 0x800000 up raised OverflowError on encode.
+    """
+    attribute = attributes.FirmwareVersionAttribute(value)
+    encoded = attribute.encode()
+    assert len(encoded) == 3
+    assert attributes.FirmwareVersionAttribute.decode(encoded) == attribute
+
+
+def test_firmware_version_formatted_value_keeps_major_version() -> None:
+    """The mask was 0xFFFFF (20 bits), which truncated the top nibble of the major byte."""
+    assert attributes.FirmwareVersionAttribute(0x900000).formatted_value() == "144.00.00"
+    assert attributes.FirmwareVersionAttribute(0x050301).formatted_value() == "05.03.01"
+
+
+def test_alarm_round_trip() -> None:
+    """changed_at/alarm_type were annotated `int | None`, which ">QB" cannot pack."""
+    alarm = codec.Alarm(changed_at=1, alarm_type=0x01)
+    decoded = codec.decode(alarm.encode())
+    assert isinstance(decoded, codec.Alarm)
+    assert decoded == alarm
+    assert decoded.alarm_message() == "Low battery"
+
+
+@pytest.mark.parametrize("message_class", [file_codec.PulseBlockEcg, file_codec.PulseBlockPpg])
+def test_pulse_block_encode_is_not_a_silent_stub(
+    message_class: type[file_codec.PulseBlockEcg] | type[file_codec.PulseBlockPpg],
+) -> None:
+    """encode() returned two zero bytes regardless of contents, which looks like valid output."""
+    message = message_class(time=1, channel=0, num_samples=1, samples=[5], pkg_length=14)
+    with pytest.raises(NotImplementedError):
+        message.encode()
+
+
+@pytest.mark.parametrize("message_class", [file_codec.PulseBlockEcg, file_codec.PulseBlockPpg])
+def test_pulse_block_rejects_short_header(
+    message_class: type[file_codec.PulseBlockEcg] | type[file_codec.PulseBlockPpg],
+) -> None:
+    """PulseBlockPpg guarded on 13 bytes while the header is 14."""
+    with pytest.raises(BufferError):
+        message_class.decode(bytes(file_codec.PULSE_BLOCK_HEADER_LENGTH - 1))


### PR DESCRIPTION
Stacked on #814 — review that first; this PR's diff is against it.

The test suite only asserted round-trips for **fixed-size** payloads. That hid a family of defects in every path whose encoded size is not static — each one corrupting bytes silently rather than raising.

### ⚠️ Breaking

`SendFileResponse.crc` → `file_crc`. The field collided with `Message.crc`, which `Message.decode` assigns the footer CRC to after construction, so the decoded file CRC was silently replaced:

```
SendFileResponse(9).encode()  ->  c300070009d8df      # payload 0x0009 encoded fine
codec.decode(...)             ->  SendFileResponse(crc=55519)   # 0xD8DF, payload lost
```

Note reading `.crc` on this class is now wrong in *more* cases than before, not fewer — it resolves to the inherited `Message.crc` rather than raising. Callers must move to `.file_crc`.

### Fixes

- **`SetAttribute` wrote a length byte of `0`** for every variable-length attribute (`Model`, `Vendor`, `SystemStatusNames`, `SystemStatus`, `PulseRawList`). It used `Attribute.length()`, a classmethod over `struct_format` that reports 0 whenever the format is empty. The payload went out on the wire but the length field said zero, so a conforming parser dropped it. Now derived from the encoded bytes, as `GetAttributeResponse` already did. **Fixed-size attributes encode identically.**
- **Attribute payloads over 255 bytes** now raise with a message naming the problem. Deriving the real length exposes this: the length field is one byte and `SystemStatusNames` has no structural cap, so a large enough list previously died on a bare `struct.error` naming only the format character.
- **`types.PulseRawList.length()` returned 0** on a constructed instance (`len` was a bare class attribute, never initialised) and under-reported by 2 after decode (the 2-byte tick was omitted). Its `file_codec` twin had this right — the copies had drifted.
- **`types.PulseRawList.decode` accepted truncated buffers** and returned zeroed samples, so a caller could not distinguish corrupt data from a short read. The twin already checked.
- **`SystemStatusNamesAttribute.encode` raised `IndexError` on an empty list** — exactly what `decode(b"")` produces.
- **`FirmwareVersionAttribute`** encoded with `signed=True` but decoded with `signed=False`, so any version ≥ `0x800000` raised `OverflowError`; and `formatted_value` masked with `0xFFFFF` (20 bits) instead of `0xFFFFFF`, truncating the major version.
- **`Alarm.changed_at`/`alarm_type`** were annotated `int | None` against a `">QB"` format that cannot pack `None`.
- **`PulseBlockEcg/Ppg.encode()`** returned two zero bytes regardless of contents. File messages are decode-only; they now raise `NotImplementedError` rather than returning something that looks valid.
- Corrected buffer-length error messages that named the wrong minimum.

### Tests

New `tests/test_variable_length_payloads.py`. Each fix was verified by reverting it alone and confirming a failure; 18 of the new assertions fail against the unfixed code. `PulseRawList` cases are parameterised over all four sample widths, and truncation is asserted against **both** implementations so they cannot drift apart again.

All existing golden-byte assertions pass unchanged. Only `test_send_file_response` changed, for the deliberate rename.