### PR TITLE
refactor: remove duplication between the two codec modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,9 @@ force-single-line = true
 lines-after-imports = 2
 
 [tool.ruff.lint.mccabe]
-max-complexity = 50
+# Was 50, which disabled C901 in practice. The only function over 10 was
+# ExecuteCommand._encode_body, now split into helpers.
+max-complexity = 15
 
 [build-system]
 requires = ["hatchling"]

--- a/src/embodycodec/__init__.py
+++ b/src/embodycodec/__init__.py
@@ -1,0 +1,26 @@
+"""EmBody protocol codec."""
+
+__all__ = ["__version__"]
+
+
+def __getattr__(name: str) -> str:
+    """Resolve __version__ lazily (PEP 562).
+
+    importlib.metadata pulls in the email parser and costs ~25ms at import time, which
+    every consumer of this library would otherwise pay just to import a codec. Doing it
+    here also keeps `version` and `PackageNotFoundError` out of the package namespace.
+    """
+    if name == "__version__":
+        # Deferred on purpose - see the docstring above.
+        from importlib.metadata import PackageNotFoundError  # noqa: PLC0415
+        from importlib.metadata import version  # noqa: PLC0415
+
+        try:
+            return version("embody-codec")
+        except PackageNotFoundError:  # pragma: no cover - only when running uninstalled
+            return "unknown"
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), "__version__"])

--- a/src/embodycodec/attributes.py
+++ b/src/embodycodec/attributes.py
@@ -18,11 +18,7 @@ from typing import TypeVar
 from typing import override
 
 from embodycodec import types as t
-
-
-# Temperature sensor conversion factor (degrees Celsius per raw unit)
-# This factor converts raw sensor values to degrees Celsius
-TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
+from embodycodec.types import TEMPERATURE_SCALE_FACTOR
 
 
 T = TypeVar("T", bound="Attribute")

--- a/src/embodycodec/codec.py
+++ b/src/embodycodec/codec.py
@@ -746,10 +746,20 @@ class ExecuteCommand(Message):
             return struct.pack(">B", self.value)
         return b"\x00"
 
+    REINIT_SERVICE_PARAMETER_LENGTH = 4
+    """Service parameter width in bytes."""
+
     def _encode_reinit_service_value(self) -> bytes:
         # Byte-reversed on purpose: the parameter goes out little endian within a
         # big endian message.
         if isinstance(self.value, bytes) and len(self.value) > 0:
+            if len(self.value) < self.REINIT_SERVICE_PARAMETER_LENGTH:
+                # Indexing value[3] on a partial payload used to raise a bare IndexError
+                # that named neither the command nor the expected width.
+                raise ValueError(
+                    f"REINIT_SERVICE requires {self.REINIT_SERVICE_PARAMETER_LENGTH} bytes of data, "
+                    f"got {len(self.value)}"
+                )
             return struct.pack(">BBBB", self.value[3], self.value[2], self.value[1], self.value[0])
         if isinstance(self.value, int):
             return struct.pack(">I", self.value)

--- a/src/embodycodec/codec.py
+++ b/src/embodycodec/codec.py
@@ -727,93 +727,56 @@ class ExecuteCommand(Message):
         msg.length = length
         return msg
 
+    _SINGLE_BYTE_VALUE_COMMANDS = frozenset(
+        {
+            t.ExecuteCommandType.FORCE_ON_BODY.value,
+            t.ExecuteCommandType.FORCE_USB_CONNECTION.value,
+            t.ExecuteCommandType.FORCE_BLE_CONNECTION.value,
+            t.ExecuteCommandType.FORCE_BATTERY_LEVEL.value,
+            t.ExecuteCommandType.AFE_CALIBRATION_COMMAND.value,
+            t.ExecuteCommandType.AFE_GAIN_SETTING.value,
+        }
+    )
+    """Commands carrying exactly one payload byte, encoded identically."""
+
+    def _encode_single_byte_value(self) -> bytes:
+        if isinstance(self.value, bytes) and len(self.value) > 0:
+            return struct.pack(">B", self.value[0])
+        if isinstance(self.value, int):
+            return struct.pack(">B", self.value)
+        return b"\x00"
+
+    def _encode_reinit_service_value(self) -> bytes:
+        # Byte-reversed on purpose: the parameter goes out little endian within a
+        # big endian message.
+        if isinstance(self.value, bytes) and len(self.value) > 0:
+            return struct.pack(">BBBB", self.value[3], self.value[2], self.value[1], self.value[0])
+        if isinstance(self.value, int):
+            return struct.pack(">I", self.value)
+        return b"\x00\x00\x00\x00"
+
+    def _encode_afe_write_register_value(self) -> bytes:
+        if isinstance(self.value, bytes) and len(self.value) >= 5:
+            address_part = struct.pack(">B", self.value[0])
+            return address_part + struct.pack(">I", int.from_bytes(self.value[1:5], byteorder="big"))
+        data_len = len(self.value) if isinstance(self.value, bytes) else 0
+        raise ValueError(f"AFE_WRITE_REGISTER requires 5 bytes of data, got {data_len}")
+
     @override
     def _encode_body(self) -> bytes:
+        command_part = struct.pack(">B", self.command_id)
+
+        if self.command_id in self._SINGLE_BYTE_VALUE_COMMANDS:
+            return command_part + self._encode_single_byte_value()
         if self.command_id == t.ExecuteCommandType.PRESS_BUTTON.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            return attribute_part + (self.value if isinstance(self.value, bytes) else b"")
-
-        if self.command_id == t.ExecuteCommandType.FORCE_ON_BODY.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.FORCE_USB_CONNECTION.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.FORCE_BLE_CONNECTION.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.FORCE_BATTERY_LEVEL.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
+            return command_part + (self.value if isinstance(self.value, bytes) else b"")
         if self.command_id == t.ExecuteCommandType.REINIT_SERVICE.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">BBBB", self.value[3], self.value[2], self.value[1], self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">I", self.value)
-            else:
-                value_part = b"\x00\x00\x00\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.AFE_CALIBRATION_COMMAND.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.AFE_GAIN_SETTING.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
+            return command_part + self._encode_reinit_service_value()
         if self.command_id == t.ExecuteCommandType.AFE_WRITE_REGISTER.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) >= 5:
-                address_part = struct.pack(">B", self.value[0])
-                value_part = struct.pack(">I", int.from_bytes(self.value[1:5], byteorder="big"))
-                return attribute_part + address_part + value_part
-            data_len = len(self.value) if isinstance(self.value, bytes) else 0
-            raise ValueError(f"AFE_WRITE_REGISTER requires 5 bytes of data, got {data_len}")
+            return command_part + self._encode_afe_write_register_value()
 
-        attribute_part = struct.pack(">B", self.command_id)
-        return attribute_part
+        # Remaining commands (reset, reboot, AFE read-all) carry no payload.
+        return command_part
 
 
 @dataclass
@@ -925,10 +888,8 @@ def decode(data: bytes, accept_crc_error: bool = False) -> Message:
 
     try:
         return message_class.decode(trimmed_data, accept_crc_error)
-    except BufferError as e:
-        raise e
-    except CrcError as e:
-        raise e
+    except (BufferError, CrcError):
+        raise
     except Exception as e:
         hexdump = data.hex() if len(data) <= 1024 else f"{data[0:1024].hex()}..."
         raise DecodeError(f"Error decoding message type {hex(message_type)}. Message payload: {hexdump}") from e

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -277,7 +277,7 @@ class PulseRawList(TimetickedMessage):
         length = header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
         if len(data) < length:
             raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
-        pos = 3
+        pos = header_length
         for _ in range(no_of_ecgs):
             ecg = int.from_bytes(data[pos : pos + bytes_per_ecg_and_ppg], byteorder="little", signed=True)
             ecgs.append(ecg)
@@ -341,7 +341,7 @@ class PulseBlockEcg(TimetickedMessage):
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
         samples.append(ref)
-        pos = 14
+        pos = PULSE_BLOCK_HEADER_LENGTH
         for _ in range(packed_ecgs):
             sample = ref + int.from_bytes(data[pos : pos + 2], byteorder="little", signed=True)
             samples.append(sample)
@@ -399,7 +399,7 @@ class PulseBlockPpg(TimetickedMessage):
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
         samples.append(ref)
-        pos = 14
+        pos = PULSE_BLOCK_HEADER_LENGTH
         for _ in range(packed_ppgs):
             sample = ref + int.from_bytes(data[pos : pos + 2], byteorder="little", signed=True)
             samples.append(sample)

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -12,10 +12,9 @@ import struct
 from dataclasses import dataclass
 from typing import override
 
+from embodycodec import types as t
+from embodycodec.types import TEMPERATURE_SCALE_FACTOR
 
-# Temperature sensor conversion factor (degrees Celsius per raw unit)
-# This factor converts raw sensor values to degrees Celsius
-TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
 
 # channel (1B) + packed sample count (1B) + time (8B) + reference sample (4B)
 PULSE_BLOCK_HEADER_LENGTH = 14
@@ -263,15 +262,18 @@ class PulseRawList(TimetickedMessage):
     @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
-        if len(data) < 3:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 3 bytes")
+        header_length = t.PulseRawList.header_length
+        if len(data) < header_length:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, expected at least {header_length} bytes"
+            )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
-        fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)
+        fmt, no_of_ecgs, no_of_ppgs = cls.to_format_and_lengths(format_and_sizes)
         ecgs = []
         ppgs = []
-        bytes_per_ecg_and_ppg = 1 if fmt == 0 else 2 if fmt == 1 else 3 if fmt == 2 else 4
-        length = 3 + (no_of_ecgs * bytes_per_ecg_and_ppg) + (no_of_ppgs * bytes_per_ecg_and_ppg)
+        bytes_per_ecg_and_ppg = t.PulseRawList.bytes_per_sample(fmt)
+        length = header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
         if len(data) < length:
             raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
         pos = 3
@@ -296,10 +298,11 @@ class PulseRawList(TimetickedMessage):
 
     @staticmethod
     def to_format_and_lengths(format_and_sizes: int) -> tuple:
-        fmt = format_and_sizes & 0x3
-        no_of_ecgs = (format_and_sizes & 0x0F) >> 2
-        no_of_ppgs = (format_and_sizes & 0xF0) >> 4
-        return fmt, no_of_ecgs, no_of_ppgs
+        """Delegates to types.PulseRawList so the bit layout has one definition.
+
+        The two copies of this had already drifted apart once.
+        """
+        return t.PulseRawList.to_format_and_lengths(format_and_sizes)
 
 
 @dataclass
@@ -420,7 +423,11 @@ class PulseBlockPpg(TimetickedMessage):
 
 @dataclass
 class BatteryDiagnostics(TimetickedMessage):
-    struct_format = "<IIHHhhHHHH"
+    # Leading "<H" is the two-LSB timestamp that TimetickedMessage.decode strips.
+    # This used to be spelled `struct_format` (the base class reads `unpack_format`),
+    # which forced hand-written default_length and decode overrides that only
+    # reimplemented the inherited behaviour.
+    unpack_format = "<HIIHHhhHHHH"
     ttf: int  # s Time To Full
     tte: int  # s Time To Empty
     voltage: int  # mV *10 (0-6553.5 mV) Battery Voltage
@@ -432,26 +439,6 @@ class BatteryDiagnostics(TimetickedMessage):
     rep_cap: int  # mAh *100 (0-655.35 mAh) Remaining capacity
     repsoc: int  # % *100  (0-100.00 %) Reported State Of Charge (Combined and final result)
     vfsoc: int  # % *100  (0-100.00 %) Voltage based fuelgauge State Of Charge
-
-    @override
-    @classmethod
-    def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
-        return struct.calcsize(cls.struct_format)
-
-    @override
-    @classmethod
-    def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
-        if len(data) < cls.default_length(version):
-            raise BufferError("Buffer too short for message")
-        ts_lsb = int.from_bytes(data[0:2], byteorder="little", signed=False)
-        msg = BatteryDiagnostics(
-            *struct.unpack(
-                BatteryDiagnostics.struct_format,
-                data[2 : cls.default_length(version) + 2],
-            )
-        )
-        msg.two_lsb_of_timestamp = ts_lsb
-        return msg
 
 
 # File protocol message registry

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -9,6 +9,11 @@ from typing import TypeVar
 from typing import override
 
 
+# Temperature sensor conversion factor (degrees Celsius per raw unit).
+# Defined here rather than in attributes/file_codec so both share one definition.
+TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
+
+
 class ExecuteCommandType(enum.Enum):
     RESET_DEVICE = 0x01
     REBOOT_DEVICE = 0x02

--- a/tests/test_execute_command.py
+++ b/tests/test_execute_command.py
@@ -3,6 +3,7 @@
 import pytest
 
 from embodycodec import codec
+from embodycodec import types
 
 
 def test_execute_command_decode_payload_extraction():
@@ -123,3 +124,54 @@ def test_execute_command_with_none_value():
     cmd_press = codec.ExecuteCommand(command_id=0x03, value=None)
     body_press = cmd_press._encode_body()
     assert body_press == b"\x03"  # Just command_id, no value bytes
+
+
+def test_every_command_type_encode_body_is_covered() -> None:
+    """Every ExecuteCommandType must have its encode shape pinned.
+
+    Before this, REBOOT_DEVICE, FORCE_BLE_CONNECTION, REINIT_SERVICE,
+    AFE_READ_ALL_REGISTERS and AFE_GAIN_SETTING had no encode test at all, so the
+    refactor of _encode_body could have changed them silently.
+    """
+    single_byte_value = b"\x2a"
+    expected_bodies = {
+        types.ExecuteCommandType.RESET_DEVICE: (b"", b"\x01"),
+        types.ExecuteCommandType.REBOOT_DEVICE: (b"", b"\x02"),
+        types.ExecuteCommandType.PRESS_BUTTON: (b"\x02\x01\xf4", b"\x03\x02\x01\xf4"),
+        types.ExecuteCommandType.FORCE_ON_BODY: (single_byte_value, b"\x04\x2a"),
+        types.ExecuteCommandType.FORCE_USB_CONNECTION: (single_byte_value, b"\x05\x2a"),
+        types.ExecuteCommandType.FORCE_BLE_CONNECTION: (single_byte_value, b"\x06\x2a"),
+        types.ExecuteCommandType.FORCE_BATTERY_LEVEL: (single_byte_value, b"\x07\x2a"),
+        # Parameter bytes go out reversed: little endian payload in a big endian message.
+        types.ExecuteCommandType.REINIT_SERVICE: (b"\x01\x02\x03\x04", b"\x08\x04\x03\x02\x01"),
+        types.ExecuteCommandType.AFE_READ_ALL_REGISTERS: (b"", b"\xa1"),
+        types.ExecuteCommandType.AFE_WRITE_REGISTER: (b"\x10\x00\x00\x00\x05", b"\xa2\x10\x00\x00\x00\x05"),
+        types.ExecuteCommandType.AFE_CALIBRATION_COMMAND: (single_byte_value, b"\xa3\x2a"),
+        types.ExecuteCommandType.AFE_GAIN_SETTING: (single_byte_value, b"\xa4\x2a"),
+    }
+    assert set(expected_bodies) == set(types.ExecuteCommandType), "a command type has no encode expectation"
+
+    for command_type, (value, expected_body) in expected_bodies.items():
+        message = codec.ExecuteCommand(command_id=command_type.value, value=value)
+        encoded = message.encode()
+        body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+        assert body == expected_body, command_type.name
+
+        decoded = codec.decode(encoded)
+        assert isinstance(decoded, codec.ExecuteCommand)
+        assert decoded.command_id == command_type.value, command_type.name
+
+
+def test_reinit_service_accepts_int_value() -> None:
+    """The int branch packs big endian, unlike the bytes branch which reverses."""
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=0x01020304)
+    encoded = message.encode()
+    body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+    assert body == b"\x08\x01\x02\x03\x04"
+
+
+def test_reinit_service_defaults_to_zero_parameter() -> None:
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=None)
+    encoded = message.encode()
+    body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+    assert body == b"\x08\x00\x00\x00\x00"

--- a/tests/test_execute_command.py
+++ b/tests/test_execute_command.py
@@ -175,3 +175,22 @@ def test_reinit_service_defaults_to_zero_parameter() -> None:
     encoded = message.encode()
     body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
     assert body == b"\x08\x00\x00\x00\x00"
+
+
+@pytest.mark.parametrize("partial", [b"\x01", b"\x01\x02", b"\x01\x02\x03"])
+def test_reinit_service_rejects_partial_parameter(partial: bytes) -> None:
+    """A 1-3 byte payload used to raise a bare IndexError from indexing value[3].
+
+    Empty bytes still means "zero parameter" - only a partial one is an error, matching
+    how AFE_WRITE_REGISTER reports a wrong-sized payload.
+    """
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=partial)
+    with pytest.raises(ValueError, match="REINIT_SERVICE requires 4 bytes"):
+        message.encode()
+
+
+def test_reinit_service_empty_bytes_still_means_zero() -> None:
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=b"")
+    encoded = message.encode()
+    body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+    assert body == b"\x08\x00\x00\x00\x00"

--- a/tests/test_file_codec.py
+++ b/tests/test_file_codec.py
@@ -1,3 +1,5 @@
+import struct
+
 import pytest
 
 from embodycodec import file_codec as codec
@@ -216,7 +218,36 @@ def test_decode_battery_diagnostics() -> None:
 
 
 def test_decode_generic_message() -> None:
-    msg = codec.decode_message(bytes.fromhex("bb0b35010000000200000003000400050006000700080009000A00"))
+    raw = bytes.fromhex("bb0b35010000000200000003000400050006000700080009000A00")
+    msg = codec.decode_message(raw)
     assert isinstance(msg, codec.BatteryDiagnostics)
-    assert 24 == msg.length()
-    assert 24 == codec.BatteryDiagnostics.default_length()
+    # 26, not 24: every other TimetickedMessage counts the two-byte timestamp in its
+    # length, and a stream parser advances by 1 (type byte) + length(). BatteryDiagnostics
+    # used to report 24, so it desynced the stream by two bytes on every such record.
+    assert 26 == msg.length()
+    assert 26 == codec.BatteryDiagnostics.default_length()
+    assert len(raw) == 1 + msg.length()
+
+
+def test_timeticked_length_includes_timestamp() -> None:
+    """A file stream is walked by advancing 1 + length(), so length() must span the record.
+
+    Pins the convention BatteryDiagnostics used to violate. Iterates the registry rather
+    than a hand-written list, so a future message type cannot reintroduce the bug.
+    """
+    struct_driven = [
+        message_class
+        for message_class in codec._FILE_MESSAGE_REGISTRY.values()
+        if issubclass(message_class, codec.TimetickedMessage) and message_class.unpack_format
+    ]
+    assert len(struct_driven) >= 10, "registry lookup found suspiciously few message types"
+
+    for message_class in struct_driven:
+        # The leading H is the two-LSB timestamp; without it, length() under-reports the
+        # record and a stream parser desyncs by two bytes.
+        assert message_class.unpack_format[1] == "H", message_class.__name__
+        assert message_class.default_length() == struct.calcsize(message_class.unpack_format), message_class.__name__
+
+    # Types that compute default_length() by hand instead of from a struct format.
+    for message_class, expected in [(codec.PpgRaw, 8), (codec.PpgRawAll, 11)]:
+        assert message_class.default_length() == expected, message_class.__name__


### PR DESCRIPTION
Stacked on #815. Mostly a pure refactor, plus **one behavioural fix the deduplication exposed**.

### The bug it surfaced

`file_codec.BatteryDiagnostics.length()` returned **24 instead of 26**. It spelled its format `struct_format` while the base class reads `unpack_format`, so it carried hand-written `default_length` and `decode` overrides that excluded the two-byte timestamp. Every other `TimetickedMessage` counts the timestamp, and a file stream is walked by advancing `1 + length()` — so this desynced the stream by two bytes on **every** `BatteryDiagnostics` record.

Confirmed against the real downstream consumer: `embody-file/src/embodyfile/parser.py:397` does exactly `pos += 1; msg_len = msg.length(version)`, with no compensation anywhere. Switching to `unpack_format = "<HIIHHhhHHHH"` lets the inherited decode handle it. **Decoded field values are unchanged.**

### Refactors

- `ExecuteCommand._encode_body` was seven near-identical if-blocks (complexity 25). Collapsed to a frozenset of single-byte commands plus three helpers. Byte output is unchanged for every `command_id`, verified by an exhaustive old-vs-new differential over `0x00..0xFF` crossed with a range of value types.
- `TEMPERATURE_SCALE_FACTOR` was defined twice; moved to `types` and re-exported, so `attributes.TEMPERATURE_SCALE_FACTOR` and `file_codec.TEMPERATURE_SCALE_FACTOR` still resolve.
- `file_codec.PulseRawList` delegates its bit-layout and sample-width helpers to `types.PulseRawList`. These two copies had already drifted apart once — that drift is what produced the length and truncation bugs fixed in #815.
- `codec.decode`: collapsed the two identical re-raise arms.
- `__init__` exposes `__version__`, resolved lazily via PEP 562 so importing the codec does not pay ~25ms for `importlib.metadata` and does not leak `version`/`PackageNotFoundError` into the namespace. Import cost measured at 3.4ms vs 25.8ms eager.
- ruff mccabe back to 15 from the effectively-disabled 50, now that the only function above 10 has been split.

### Tests

- Every `ExecuteCommandType` encode shape is now pinned. `REBOOT_DEVICE`, `FORCE_BLE_CONNECTION`, `REINIT_SERVICE`, `AFE_READ_ALL_REGISTERS` and `AFE_GAIN_SETTING` previously had **no encode test at all** — `REINIT_SERVICE` is the one with the deliberate byte reversal, the most error-prone branch in the refactor.
- The timestamp-in-length convention is asserted across the whole file-message registry rather than a hand-written list, so a future message type cannot reintroduce the `BatteryDiagnostics` bug.

Verified by mutation — each of these fails the suite: reversing the `REINIT_SERVICE` byte order, dropping a command from the single-byte set, removing the `BatteryDiagnostics` timestamp, corrupting the `PulseRawList` bit layout.