### PR TITLE
build: release 2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # release-drafter reads merged PRs to categorise the notes. Once a permissions
+      # block exists, every unlisted scope is none, so this must be explicit.
+      pull-requests: read
     steps:
       - name: Check out the repository
         # zizmor: ignore[artipacked]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,40 @@ except DecodeError as e:
     print(f"Decode failed: {e}")
 ```
 
+## Upgrading to 2.0.0
+
+Every break below is the removal of an API that never worked correctly. Nothing here
+changes behaviour that was previously right.
+
+**`codec.SendFileResponse.crc` is renamed to `file_crc`.** The old name collided with
+`Message.crc`, which holds the message footer CRC and is assigned during decode — so the
+file CRC was silently overwritten. Reading `.crc` on this class never returns the file
+CRC, so it must be replaced rather than left alone:
+
+```python
+SendFileResponse(crc=x)   ->  SendFileResponse(file_crc=x)
+response.crc              ->  response.file_crc
+```
+
+**`file_codec.BatteryDiagnostics.length()` returns 26, not 24.** It excluded the two-byte
+timestamp that every other message counts, so a parser walking a file by advancing
+`1 + length()` desynced by two bytes on every such record. If you compensated for this,
+remove the compensation.
+
+**`file_codec.BatteryDiagnostics.struct_format` is gone**, replaced by `unpack_format`
+(the name its base class actually reads). Note this is the `file_codec` class; the
+unrelated `types.BatteryDiagnostics.struct_format` is unchanged.
+
+**`file_codec.PulseBlockEcg.encode()` and `PulseBlockPpg.encode()` raise
+`NotImplementedError`.** They previously returned two zero bytes regardless of contents.
+File-format messages are produced by the device and are decode-only.
+
+One fix that needs no code change but does change bytes on the wire: `SetAttribute` now
+writes the true payload length for variable-length attributes (`ModelAttribute`,
+`VendorAttribute`, `SystemStatusNamesAttribute`, `SystemStatusAttribute`,
+`PulseRawListAttribute`). It previously wrote `0`, so a conforming parser dropped those
+values. Fixed-size attributes encode exactly as before.
+
 ## Changelog
 
 See the [releases page](https://github.com/aidee-health/embody-codec/releases) for the changelog.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,20 @@
 [project]
 name = "embody-codec"
-version = "1.0.40"
+version = "2.0.0"
 description = "Embody Codec"
 authors = [{name = "Aidee Health AS", email = "hello@aidee.io"}]
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
-classifiers = ["Development Status :: 5 - Production/Stable"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+    "Typing :: Typed",
+]
 
 [project.urls]
 Changelog = "https://github.com/aidee-health/embody-codec/releases"

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "embody-codec"
-version = "1.0.40"
+version = "2.0.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Stacked on #816. Merging this to `main` is what tags and publishes — `release.yml` only pushes to PyPI when the version in `pyproject.toml` changes, so #814–#816 merge without releasing anything.

### Why major, not minor

The stack removes four APIs. Each never worked correctly, but semver governs 1.x exactly as it does 2.x — any backward-incompatible change requires a major bump:

| Removed / changed | Was |
|---|---|
| `SendFileResponse.crc` → `file_crc` | returned the message footer CRC, never the file CRC |
| `BatteryDiagnostics.length()` 24 → 26 | desynced file streams by 2 bytes per record |
| `BatteryDiagnostics.struct_format` → `unpack_format` | the base class never read it |
| `PulseBlockEcg/Ppg.encode()` now raises | returned two zero bytes regardless of contents |

I originally planned 1.1.0; a review pass caught that as wrong and it was corrected.

### Downstream check

`embody-file` is the only consumer of any of these. It pins `embody-codec>=1.0.32` with no upper bound, so a major bump does not block it, and it uses none of the renamed or removed APIs. It *does* walk file streams with `msg.length()`, so it picks up the `BatteryDiagnostics` fix.

### Also here

- Added the missing Python-version and typing classifiers, so the PyPI "Python Version" badge in the README resolves — it currently renders from an empty classifier set. All seven validated against the trove list.
- README upgrade notes covering each break plus the `SetAttribute` wire change.
- `release.yml`: granted the release job `pull-requests: read`. Once a `permissions` block exists every unlisted scope is `none`, and release-drafter reads merged PRs to categorise the notes — publishing would have 403'd *after* the PyPI upload already succeeded.

### Verified

`uv lock --locked` passes; the version-extraction command in `release.yml` returns `2.0.0`; wheel and sdist both build and contain `py.typed` and every module.

**Before merging:** confirm the drafted release notes read correctly — release-drafter categorises purely by label, so #814–#816 need `ci`, `bug`+`breaking`, and `refactoring` respectively.