### PR TITLE
build: release 2.0.0 (recovers #815, #816, #817 stranded by stacked-branch deletion)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # release-drafter reads merged PRs to categorise the notes. Once a permissions
+      # block exists, every unlisted scope is none, so this must be explicit.
+      pull-requests: read
     steps:
       - name: Check out the repository
         # zizmor: ignore[artipacked]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,40 @@ except DecodeError as e:
     print(f"Decode failed: {e}")
 ```
 
+## Upgrading to 2.0.0
+
+Every break below is the removal of an API that never worked correctly. Nothing here
+changes behaviour that was previously right.
+
+**`codec.SendFileResponse.crc` is renamed to `file_crc`.** The old name collided with
+`Message.crc`, which holds the message footer CRC and is assigned during decode — so the
+file CRC was silently overwritten. Reading `.crc` on this class never returns the file
+CRC, so it must be replaced rather than left alone:
+
+```python
+SendFileResponse(crc=x)   ->  SendFileResponse(file_crc=x)
+response.crc              ->  response.file_crc
+```
+
+**`file_codec.BatteryDiagnostics.length()` returns 26, not 24.** It excluded the two-byte
+timestamp that every other message counts, so a parser walking a file by advancing
+`1 + length()` desynced by two bytes on every such record. If you compensated for this,
+remove the compensation.
+
+**`file_codec.BatteryDiagnostics.struct_format` is gone**, replaced by `unpack_format`
+(the name its base class actually reads). Note this is the `file_codec` class; the
+unrelated `types.BatteryDiagnostics.struct_format` is unchanged.
+
+**`file_codec.PulseBlockEcg.encode()` and `PulseBlockPpg.encode()` raise
+`NotImplementedError`.** They previously returned two zero bytes regardless of contents.
+File-format messages are produced by the device and are decode-only.
+
+One fix that needs no code change but does change bytes on the wire: `SetAttribute` now
+writes the true payload length for variable-length attributes (`ModelAttribute`,
+`VendorAttribute`, `SystemStatusNamesAttribute`, `SystemStatusAttribute`,
+`PulseRawListAttribute`). It previously wrote `0`, so a conforming parser dropped those
+values. Fixed-size attributes encode exactly as before.
+
 ## Changelog
 
 See the [releases page](https://github.com/aidee-health/embody-codec/releases) for the changelog.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,9 @@ force-single-line = true
 lines-after-imports = 2
 
 [tool.ruff.lint.mccabe]
-max-complexity = 50
+# Was 50, which disabled C901 in practice. The only function over 10 was
+# ExecuteCommand._encode_body, now split into helpers.
+max-complexity = 15
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,20 @@
 [project]
 name = "embody-codec"
-version = "1.0.40"
+version = "2.0.0"
 description = "Embody Codec"
 authors = [{name = "Aidee Health AS", email = "hello@aidee.io"}]
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
-classifiers = ["Development Status :: 5 - Production/Stable"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+    "Typing :: Typed",
+]
 
 [project.urls]
 Changelog = "https://github.com/aidee-health/embody-codec/releases"

--- a/src/embodycodec/__init__.py
+++ b/src/embodycodec/__init__.py
@@ -1,0 +1,26 @@
+"""EmBody protocol codec."""
+
+__all__ = ["__version__"]
+
+
+def __getattr__(name: str) -> str:
+    """Resolve __version__ lazily (PEP 562).
+
+    importlib.metadata pulls in the email parser and costs ~25ms at import time, which
+    every consumer of this library would otherwise pay just to import a codec. Doing it
+    here also keeps `version` and `PackageNotFoundError` out of the package namespace.
+    """
+    if name == "__version__":
+        # Deferred on purpose - see the docstring above.
+        from importlib.metadata import PackageNotFoundError  # noqa: PLC0415
+        from importlib.metadata import version  # noqa: PLC0415
+
+        try:
+            return version("embody-codec")
+        except PackageNotFoundError:  # pragma: no cover - only when running uninstalled
+            return "unknown"
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), "__version__"])

--- a/src/embodycodec/attributes.py
+++ b/src/embodycodec/attributes.py
@@ -43,6 +43,12 @@ class Attribute(ABC):
 
     @classmethod
     def length(cls) -> int:
+        """Static size of this attribute in bytes.
+
+        Only meaningful for fixed-size attributes. Subclasses with a variable-size
+        payload leave `struct_format` empty and so report 0 here — use
+        `len(instance.encode())` when the real encoded size is needed.
+        """
         return struct.calcsize(cls.struct_format)
 
     @classmethod
@@ -136,7 +142,9 @@ class FirmwareVersionAttribute(Attribute):
 
     @override
     def encode(self) -> bytes:
-        return int.to_bytes(self.value, length=3, byteorder="big", signed=True)
+        # signed=False to match decode(). With signed=True this raised OverflowError for
+        # any version >= 0x800000, i.e. major version 128 and up.
+        return int.to_bytes(self.value, length=3, byteorder="big", signed=False)
 
     @override
     @classmethod
@@ -145,7 +153,9 @@ class FirmwareVersionAttribute(Attribute):
 
     @override
     def formatted_value(self) -> str | None:
-        newval = (self.value & 0xFFFFF).to_bytes(3, "big", signed=True)
+        # 0xFFFFFF, not 0xFFFFF: the value is three bytes (24 bits), and the 20-bit mask
+        # silently truncated the major version.
+        newval = (self.value & 0xFFFFFF).to_bytes(3, "big", signed=False)
         return ".".join(str(newval[i]).zfill(2) for i in range(0, len(newval), 1))
 
 
@@ -222,11 +232,9 @@ class SystemStatusNamesAttribute(Attribute):
 
     @override
     def encode(self) -> bytes:
-        body = b""
-        for n in self.value[:-1]:
-            body += bytes(n, "ascii") + b","
-        body += bytes(self.value[-1], "ascii")
-        return body
+        # join, not value[-1]: decode(b"") yields an empty list, and indexing it raised
+        # IndexError on the empty round-trip.
+        return b",".join(bytes(n, "ascii") for n in self.value)
 
 
 @dataclass

--- a/src/embodycodec/attributes.py
+++ b/src/embodycodec/attributes.py
@@ -18,11 +18,7 @@ from typing import TypeVar
 from typing import override
 
 from embodycodec import types as t
-
-
-# Temperature sensor conversion factor (degrees Celsius per raw unit)
-# This factor converts raw sensor values to degrees Celsius
-TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
+from embodycodec.types import TEMPERATURE_SCALE_FACTOR
 
 
 T = TypeVar("T", bound="Attribute")

--- a/src/embodycodec/codec.py
+++ b/src/embodycodec/codec.py
@@ -746,10 +746,20 @@ class ExecuteCommand(Message):
             return struct.pack(">B", self.value)
         return b"\x00"
 
+    REINIT_SERVICE_PARAMETER_LENGTH = 4
+    """Service parameter width in bytes."""
+
     def _encode_reinit_service_value(self) -> bytes:
         # Byte-reversed on purpose: the parameter goes out little endian within a
         # big endian message.
         if isinstance(self.value, bytes) and len(self.value) > 0:
+            if len(self.value) < self.REINIT_SERVICE_PARAMETER_LENGTH:
+                # Indexing value[3] on a partial payload used to raise a bare IndexError
+                # that named neither the command nor the expected width.
+                raise ValueError(
+                    f"REINIT_SERVICE requires {self.REINIT_SERVICE_PARAMETER_LENGTH} bytes of data, "
+                    f"got {len(self.value)}"
+                )
             return struct.pack(">BBBB", self.value[3], self.value[2], self.value[1], self.value[0])
         if isinstance(self.value, int):
             return struct.pack(">I", self.value)

--- a/src/embodycodec/codec.py
+++ b/src/embodycodec/codec.py
@@ -26,6 +26,23 @@ from embodycodec.exceptions import DecodeError
 T = TypeVar("T", bound="Message")
 AT = TypeVar("AT", bound="a.Attribute")
 
+MAX_ATTRIBUTE_LENGTH = 0xFF
+"""The attribute length field is a single unsigned byte."""
+
+
+def _encode_attribute_length(attribute_part: bytes) -> bytes:
+    """Pack the one-byte attribute length, refusing payloads that do not fit.
+
+    Without the check, struct raises a bare `struct.error` mentioning only the format
+    character, which says nothing about which attribute was too large.
+    """
+    if len(attribute_part) > MAX_ATTRIBUTE_LENGTH:
+        raise ValueError(
+            f"Attribute payload is {len(attribute_part)} bytes, but the protocol length "
+            f"field holds at most {MAX_ATTRIBUTE_LENGTH}"
+        )
+    return struct.pack(">B", len(attribute_part))
+
 
 @dataclass
 class Message(ABC):
@@ -186,10 +203,11 @@ class SetAttribute(Message):
 
     @override
     def _encode_body(self) -> bytes:
-        first_part_of_body = struct.pack(">B", self.attribute_id)
-        length_part = struct.pack(">B", self.value.length())
+        # The length must come from the encoded bytes, not from Attribute.length(),
+        # which is a classmethod over struct_format and therefore reports 0 for every
+        # variable-length attribute (strings, system status, pulse raw lists).
         attribute_part = self.value.encode()
-        return first_part_of_body + length_part + attribute_part
+        return struct.pack(">B", self.attribute_id) + _encode_attribute_length(attribute_part) + attribute_part
 
 
 @dataclass
@@ -238,8 +256,7 @@ class GetAttributeResponse(Message):
         first_part_of_body = struct.pack(">BQ", self.attribute_id, self.changed_at)
         reporting_part = self.reporting.encode()
         attribute_part = self.value.encode()
-        length_part = struct.pack(">B", len(attribute_part))
-        return first_part_of_body + reporting_part + length_part + attribute_part
+        return first_part_of_body + reporting_part + _encode_attribute_length(attribute_part) + attribute_part
 
     def value_as(self, attr_type: type[AT]) -> AT:
         """Type-safe accessor for the attribute value with runtime type checking."""
@@ -362,8 +379,7 @@ class AttributeChanged(Message):
     def _encode_body(self) -> bytes:
         first_part_of_body = struct.pack(">QB", self.changed_at, self.attribute_id)
         attribute_part = self.value.encode()
-        length_part = struct.pack(">B", len(attribute_part))
-        return first_part_of_body + length_part + attribute_part
+        return first_part_of_body + _encode_attribute_length(attribute_part) + attribute_part
 
 
 @dataclass
@@ -441,12 +457,12 @@ class Alarm(Message):
     struct_format = ">QB"
     alarm_types = {0x01: "Low battery", 0x02: "Device off body", 0x03: "Device error"}
     msg_type = 0x31
-    changed_at: int | None
-    alarm_type: int | None
+    # Not optional: struct_format ">QB" cannot pack None, so an Alarm holding None
+    # raises struct.error on encode(). The annotation must not promise otherwise.
+    changed_at: int
+    alarm_type: int
 
     def alarm_message(self) -> str | None:
-        if self.alarm_type is None:
-            return None
         return self.alarm_types.get(self.alarm_type)
 
 
@@ -591,7 +607,14 @@ class SendFile(Message):
 class SendFileResponse(Message):
     struct_format = ">H"
     msg_type = 0xC3
-    crc: int
+
+    file_crc: int
+    """CRC of the transferred file.
+
+    Note: this must not be named `crc`. `Message.crc` holds the message footer CRC and
+    is assigned by `Message.decode` after construction, so a field of that name would be
+    overwritten with the footer value during every decode.
+    """
 
 
 @dataclass

--- a/src/embodycodec/codec.py
+++ b/src/embodycodec/codec.py
@@ -727,93 +727,56 @@ class ExecuteCommand(Message):
         msg.length = length
         return msg
 
+    _SINGLE_BYTE_VALUE_COMMANDS = frozenset(
+        {
+            t.ExecuteCommandType.FORCE_ON_BODY.value,
+            t.ExecuteCommandType.FORCE_USB_CONNECTION.value,
+            t.ExecuteCommandType.FORCE_BLE_CONNECTION.value,
+            t.ExecuteCommandType.FORCE_BATTERY_LEVEL.value,
+            t.ExecuteCommandType.AFE_CALIBRATION_COMMAND.value,
+            t.ExecuteCommandType.AFE_GAIN_SETTING.value,
+        }
+    )
+    """Commands carrying exactly one payload byte, encoded identically."""
+
+    def _encode_single_byte_value(self) -> bytes:
+        if isinstance(self.value, bytes) and len(self.value) > 0:
+            return struct.pack(">B", self.value[0])
+        if isinstance(self.value, int):
+            return struct.pack(">B", self.value)
+        return b"\x00"
+
+    def _encode_reinit_service_value(self) -> bytes:
+        # Byte-reversed on purpose: the parameter goes out little endian within a
+        # big endian message.
+        if isinstance(self.value, bytes) and len(self.value) > 0:
+            return struct.pack(">BBBB", self.value[3], self.value[2], self.value[1], self.value[0])
+        if isinstance(self.value, int):
+            return struct.pack(">I", self.value)
+        return b"\x00\x00\x00\x00"
+
+    def _encode_afe_write_register_value(self) -> bytes:
+        if isinstance(self.value, bytes) and len(self.value) >= 5:
+            address_part = struct.pack(">B", self.value[0])
+            return address_part + struct.pack(">I", int.from_bytes(self.value[1:5], byteorder="big"))
+        data_len = len(self.value) if isinstance(self.value, bytes) else 0
+        raise ValueError(f"AFE_WRITE_REGISTER requires 5 bytes of data, got {data_len}")
+
     @override
     def _encode_body(self) -> bytes:
+        command_part = struct.pack(">B", self.command_id)
+
+        if self.command_id in self._SINGLE_BYTE_VALUE_COMMANDS:
+            return command_part + self._encode_single_byte_value()
         if self.command_id == t.ExecuteCommandType.PRESS_BUTTON.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            return attribute_part + (self.value if isinstance(self.value, bytes) else b"")
-
-        if self.command_id == t.ExecuteCommandType.FORCE_ON_BODY.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.FORCE_USB_CONNECTION.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.FORCE_BLE_CONNECTION.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.FORCE_BATTERY_LEVEL.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
+            return command_part + (self.value if isinstance(self.value, bytes) else b"")
         if self.command_id == t.ExecuteCommandType.REINIT_SERVICE.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">BBBB", self.value[3], self.value[2], self.value[1], self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">I", self.value)
-            else:
-                value_part = b"\x00\x00\x00\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.AFE_CALIBRATION_COMMAND.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
-        if self.command_id == t.ExecuteCommandType.AFE_GAIN_SETTING.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) > 0:
-                value_part = struct.pack(">B", self.value[0])
-            elif isinstance(self.value, int):
-                value_part = struct.pack(">B", self.value)
-            else:
-                value_part = b"\x00"
-            return attribute_part + value_part
-
+            return command_part + self._encode_reinit_service_value()
         if self.command_id == t.ExecuteCommandType.AFE_WRITE_REGISTER.value:
-            attribute_part = struct.pack(">B", self.command_id)
-            if isinstance(self.value, bytes) and len(self.value) >= 5:
-                address_part = struct.pack(">B", self.value[0])
-                value_part = struct.pack(">I", int.from_bytes(self.value[1:5], byteorder="big"))
-                return attribute_part + address_part + value_part
-            data_len = len(self.value) if isinstance(self.value, bytes) else 0
-            raise ValueError(f"AFE_WRITE_REGISTER requires 5 bytes of data, got {data_len}")
+            return command_part + self._encode_afe_write_register_value()
 
-        attribute_part = struct.pack(">B", self.command_id)
-        return attribute_part
+        # Remaining commands (reset, reboot, AFE read-all) carry no payload.
+        return command_part
 
 
 @dataclass
@@ -925,10 +888,8 @@ def decode(data: bytes, accept_crc_error: bool = False) -> Message:
 
     try:
         return message_class.decode(trimmed_data, accept_crc_error)
-    except BufferError as e:
-        raise e
-    except CrcError as e:
-        raise e
+    except (BufferError, CrcError):
+        raise
     except Exception as e:
         hexdump = data.hex() if len(data) <= 1024 else f"{data[0:1024].hex()}..."
         raise DecodeError(f"Error decoding message type {hex(message_type)}. Message payload: {hexdump}") from e

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -17,6 +17,9 @@ from typing import override
 # This factor converts raw sensor values to degrees Celsius
 TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
 
+# channel (1B) + packed sample count (1B) + time (8B) + reference sample (4B)
+PULSE_BLOCK_HEADER_LENGTH = 14
+
 
 @dataclass
 class ProtocolMessage:
@@ -261,7 +264,7 @@ class PulseRawList(TimetickedMessage):
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < 3:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 10 bytes")
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 3 bytes")
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
         fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)
@@ -320,13 +323,16 @@ class PulseBlockEcg(TimetickedMessage):
     @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None) -> "PulseBlockEcg":
-        if len(data) < 14:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+        if len(data) < PULSE_BLOCK_HEADER_LENGTH:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least {PULSE_BLOCK_HEADER_LENGTH} bytes"
+            )
         channel = data[0]
         packed_ecgs = data[1]
-        pkg_length = 1 + 1 + 8 + 4 + (packed_ecgs * 2)
+        pkg_length = PULSE_BLOCK_HEADER_LENGTH + (packed_ecgs * 2)
         if len(data) < pkg_length:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {pkg_length} bytes")
         (time,) = struct.unpack("<Q", data[2:10])
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
@@ -346,8 +352,12 @@ class PulseBlockEcg(TimetickedMessage):
         return msg
 
     def encode(self) -> bytes:
-        payload = struct.pack("<H", 0)
-        return payload
+        # Was a stub returning b"\x00\x00" regardless of contents, which looks like a
+        # valid encoding. File-format messages are produced by the device and only ever
+        # decoded here.
+        raise NotImplementedError(
+            f"{type(self).__name__} is decode-only; file messages are not encoded by this library"
+        )
 
 
 @dataclass
@@ -371,13 +381,16 @@ class PulseBlockPpg(TimetickedMessage):
     @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None) -> "PulseBlockPpg":
-        if len(data) < 13:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+        if len(data) < PULSE_BLOCK_HEADER_LENGTH:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least {PULSE_BLOCK_HEADER_LENGTH} bytes"
+            )
         channel = data[0]
         packed_ppgs = data[1]
-        pkg_length = 1 + 1 + 8 + 4 + (packed_ppgs * 2)
+        pkg_length = PULSE_BLOCK_HEADER_LENGTH + (packed_ppgs * 2)
         if len(data) < pkg_length:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 13 bytes")
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {pkg_length} bytes")
         (time,) = struct.unpack("<Q", data[2:10])
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
@@ -397,8 +410,12 @@ class PulseBlockPpg(TimetickedMessage):
         return msg
 
     def encode(self) -> bytes:
-        payload = struct.pack("<H", 0)
-        return payload
+        # Was a stub returning b"\x00\x00" regardless of contents, which looks like a
+        # valid encoding. File-format messages are produced by the device and only ever
+        # decoded here.
+        raise NotImplementedError(
+            f"{type(self).__name__} is decode-only; file messages are not encoded by this library"
+        )
 
 
 @dataclass

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -277,7 +277,7 @@ class PulseRawList(TimetickedMessage):
         length = header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
         if len(data) < length:
             raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
-        pos = 3
+        pos = header_length
         for _ in range(no_of_ecgs):
             ecg = int.from_bytes(data[pos : pos + bytes_per_ecg_and_ppg], byteorder="little", signed=True)
             ecgs.append(ecg)
@@ -341,7 +341,7 @@ class PulseBlockEcg(TimetickedMessage):
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
         samples.append(ref)
-        pos = 14
+        pos = PULSE_BLOCK_HEADER_LENGTH
         for _ in range(packed_ecgs):
             sample = ref + int.from_bytes(data[pos : pos + 2], byteorder="little", signed=True)
             samples.append(sample)
@@ -399,7 +399,7 @@ class PulseBlockPpg(TimetickedMessage):
         samples = []
         ref = int.from_bytes(data[10:14], byteorder="little", signed=True)
         samples.append(ref)
-        pos = 14
+        pos = PULSE_BLOCK_HEADER_LENGTH
         for _ in range(packed_ppgs):
             sample = ref + int.from_bytes(data[pos : pos + 2], byteorder="little", signed=True)
             samples.append(sample)

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -264,7 +264,10 @@ class PulseRawList(TimetickedMessage):
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
         if len(data) < 3:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 3 bytes")
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least 3 bytes to determine the full length"
+            )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
         fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)

--- a/src/embodycodec/file_codec.py
+++ b/src/embodycodec/file_codec.py
@@ -12,10 +12,9 @@ import struct
 from dataclasses import dataclass
 from typing import override
 
+from embodycodec import types as t
+from embodycodec.types import TEMPERATURE_SCALE_FACTOR
 
-# Temperature sensor conversion factor (degrees Celsius per raw unit)
-# This factor converts raw sensor values to degrees Celsius
-TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
 
 # channel (1B) + packed sample count (1B) + time (8B) + reference sample (4B)
 PULSE_BLOCK_HEADER_LENGTH = 14
@@ -263,15 +262,18 @@ class PulseRawList(TimetickedMessage):
     @override
     @classmethod
     def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
-        if len(data) < 3:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 3 bytes")
+        header_length = t.PulseRawList.header_length
+        if len(data) < header_length:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, expected at least {header_length} bytes"
+            )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
-        fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)
+        fmt, no_of_ecgs, no_of_ppgs = cls.to_format_and_lengths(format_and_sizes)
         ecgs = []
         ppgs = []
-        bytes_per_ecg_and_ppg = 1 if fmt == 0 else 2 if fmt == 1 else 3 if fmt == 2 else 4
-        length = 3 + (no_of_ecgs * bytes_per_ecg_and_ppg) + (no_of_ppgs * bytes_per_ecg_and_ppg)
+        bytes_per_ecg_and_ppg = t.PulseRawList.bytes_per_sample(fmt)
+        length = header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
         if len(data) < length:
             raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
         pos = 3
@@ -296,10 +298,11 @@ class PulseRawList(TimetickedMessage):
 
     @staticmethod
     def to_format_and_lengths(format_and_sizes: int) -> tuple:
-        fmt = format_and_sizes & 0x3
-        no_of_ecgs = (format_and_sizes & 0x0F) >> 2
-        no_of_ppgs = (format_and_sizes & 0xF0) >> 4
-        return fmt, no_of_ecgs, no_of_ppgs
+        """Delegates to types.PulseRawList so the bit layout has one definition.
+
+        The two copies of this had already drifted apart once.
+        """
+        return t.PulseRawList.to_format_and_lengths(format_and_sizes)
 
 
 @dataclass
@@ -420,7 +423,11 @@ class PulseBlockPpg(TimetickedMessage):
 
 @dataclass
 class BatteryDiagnostics(TimetickedMessage):
-    struct_format = "<IIHHhhHHHH"
+    # Leading "<H" is the two-LSB timestamp that TimetickedMessage.decode strips.
+    # This used to be spelled `struct_format` (the base class reads `unpack_format`),
+    # which forced hand-written default_length and decode overrides that only
+    # reimplemented the inherited behaviour.
+    unpack_format = "<HIIHHhhHHHH"
     ttf: int  # s Time To Full
     tte: int  # s Time To Empty
     voltage: int  # mV *10 (0-6553.5 mV) Battery Voltage
@@ -432,26 +439,6 @@ class BatteryDiagnostics(TimetickedMessage):
     rep_cap: int  # mAh *100 (0-655.35 mAh) Remaining capacity
     repsoc: int  # % *100  (0-100.00 %) Reported State Of Charge (Combined and final result)
     vfsoc: int  # % *100  (0-100.00 %) Voltage based fuelgauge State Of Charge
-
-    @override
-    @classmethod
-    def default_length(cls, version: tuple[int, int, int] | None = None) -> int:
-        return struct.calcsize(cls.struct_format)
-
-    @override
-    @classmethod
-    def decode(cls, data: bytes, version: tuple[int, int, int] | None = None):
-        if len(data) < cls.default_length(version):
-            raise BufferError("Buffer too short for message")
-        ts_lsb = int.from_bytes(data[0:2], byteorder="little", signed=False)
-        msg = BatteryDiagnostics(
-            *struct.unpack(
-                BatteryDiagnostics.struct_format,
-                data[2 : cls.default_length(version) + 2],
-            )
-        )
-        msg.two_lsb_of_timestamp = ts_lsb
-        return msg
 
 
 # File protocol message registry

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -143,7 +143,7 @@ class PulseRawList(ComplexType):
         length = cls.header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
         if len(data) < length:
             raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
-        pos = 3
+        pos = cls.header_length
         for _ in range(no_of_ecgs):
             ecg = int.from_bytes(data[pos : pos + bytes_per_ecg_and_ppg], byteorder="little", signed=True)
             ecgs.append(ecg)

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -129,7 +129,8 @@ class PulseRawList(ComplexType):
     def decode(cls, data: bytes) -> "PulseRawList":
         if len(data) < cls.header_length:
             raise BufferError(
-                f"Buffer too short for message. Received {len(data)} bytes, expected at least {cls.header_length} bytes"
+                f"Buffer too short for message. Received {len(data)} bytes, "
+                f"expected at least {cls.header_length} bytes to determine the full length"
             )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -9,6 +9,11 @@ from typing import TypeVar
 from typing import override
 
 
+# Temperature sensor conversion factor (degrees Celsius per raw unit).
+# Defined here rather than in attributes/file_codec so both share one definition.
+TEMPERATURE_SCALE_FACTOR = 0.0078125  # 1/128
+
+
 class ExecuteCommandType(enum.Enum):
     RESET_DEVICE = 0x01
     REBOOT_DEVICE = 0x02

--- a/src/embodycodec/types.py
+++ b/src/embodycodec/types.py
@@ -105,23 +105,43 @@ class PulseRawList(ComplexType):
     no_of_ppgs: int
     ecgs: list[int]
     ppgs: list[int]
+
+    header_length = 3
+    """tick (2 bytes, little endian) + packed format/sizes byte"""
+
     len = 0
+    """Deprecated, kept for backwards compatibility. Set by decode(); use length() instead.
+
+    Note: intentionally not a dataclass field, so it stays out of __eq__ and astuple().
+    """
+
+    @staticmethod
+    def bytes_per_sample(fmt: int) -> int:
+        """Sample width in bytes for a given wire format (0-3)."""
+        return 1 if fmt == 0 else 2 if fmt == 1 else 3 if fmt == 2 else 4
 
     @override
     def length(self) -> int:
-        return self.len
+        return self.header_length + (self.no_of_ecgs + self.no_of_ppgs) * self.bytes_per_sample(self.format)
 
     @override
     @classmethod
     def decode(cls, data: bytes) -> "PulseRawList":
-        if len(data) < 10:
-            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected at least 10 bytes")
+        if len(data) < cls.header_length:
+            raise BufferError(
+                f"Buffer too short for message. Received {len(data)} bytes, expected at least {cls.header_length} bytes"
+            )
         (tick,) = struct.unpack("<H", data[0:2])
         (format_and_sizes,) = struct.unpack("<B", data[2:3])
         fmt, no_of_ecgs, no_of_ppgs = PulseRawList.to_format_and_lengths(format_and_sizes)
         ecgs = []
         ppgs = []
-        bytes_per_ecg_and_ppg = 1 if fmt == 0 else 2 if fmt == 1 else 3 if fmt == 2 else 4
+        bytes_per_ecg_and_ppg = cls.bytes_per_sample(fmt)
+        # Without this, int.from_bytes() on short slices silently yields zeros instead
+        # of reporting that the caller needs to buffer more data.
+        length = cls.header_length + (no_of_ecgs + no_of_ppgs) * bytes_per_ecg_and_ppg
+        if len(data) < length:
+            raise BufferError(f"Buffer too short for message. Received {len(data)} bytes, expected {length} bytes")
         pos = 3
         for _ in range(no_of_ecgs):
             ecg = int.from_bytes(data[pos : pos + bytes_per_ecg_and_ppg], byteorder="little", signed=True)
@@ -139,13 +159,13 @@ class PulseRawList(ComplexType):
             ecgs=ecgs,
             ppgs=ppgs,
         )
-        msg.len = 1 + (no_of_ecgs * bytes_per_ecg_and_ppg) + (no_of_ppgs * bytes_per_ecg_and_ppg)
+        msg.len = length
         return msg
 
     @override
     def encode(self) -> bytes:
         format_and_length = PulseRawList.from_format_and_lengths(self.format, self.no_of_ecgs, self.no_of_ppgs)
-        bytes_per_ecg_and_ppg = 1 if self.format == 0 else 2 if self.format == 1 else 3 if self.format == 2 else 4
+        bytes_per_ecg_and_ppg = self.bytes_per_sample(self.format)
         payload = struct.pack("<H", self.tick)
         payload += struct.pack("<B", format_and_length)
         for element in range(self.no_of_ecgs):

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -678,12 +678,14 @@ def test_send_file() -> None:
 
 
 def test_send_file_response() -> None:
-    response = codec.SendFileResponse(9)
+    response = codec.SendFileResponse(file_crc=9)
     encoded = response.encode()
     assert encoded == b"\xc3\x00\x07\x00\t\xd8\xdf"
     decoded = codec.decode(encoded)
     assert isinstance(decoded, codec.SendFileResponse)
     assert decoded.length == 7
+    assert decoded.file_crc == 9
+    assert decoded == response
 
 
 def test_delete_file() -> None:

--- a/tests/test_execute_command.py
+++ b/tests/test_execute_command.py
@@ -3,6 +3,7 @@
 import pytest
 
 from embodycodec import codec
+from embodycodec import types
 
 
 def test_execute_command_decode_payload_extraction():
@@ -123,3 +124,54 @@ def test_execute_command_with_none_value():
     cmd_press = codec.ExecuteCommand(command_id=0x03, value=None)
     body_press = cmd_press._encode_body()
     assert body_press == b"\x03"  # Just command_id, no value bytes
+
+
+def test_every_command_type_encode_body_is_covered() -> None:
+    """Every ExecuteCommandType must have its encode shape pinned.
+
+    Before this, REBOOT_DEVICE, FORCE_BLE_CONNECTION, REINIT_SERVICE,
+    AFE_READ_ALL_REGISTERS and AFE_GAIN_SETTING had no encode test at all, so the
+    refactor of _encode_body could have changed them silently.
+    """
+    single_byte_value = b"\x2a"
+    expected_bodies = {
+        types.ExecuteCommandType.RESET_DEVICE: (b"", b"\x01"),
+        types.ExecuteCommandType.REBOOT_DEVICE: (b"", b"\x02"),
+        types.ExecuteCommandType.PRESS_BUTTON: (b"\x02\x01\xf4", b"\x03\x02\x01\xf4"),
+        types.ExecuteCommandType.FORCE_ON_BODY: (single_byte_value, b"\x04\x2a"),
+        types.ExecuteCommandType.FORCE_USB_CONNECTION: (single_byte_value, b"\x05\x2a"),
+        types.ExecuteCommandType.FORCE_BLE_CONNECTION: (single_byte_value, b"\x06\x2a"),
+        types.ExecuteCommandType.FORCE_BATTERY_LEVEL: (single_byte_value, b"\x07\x2a"),
+        # Parameter bytes go out reversed: little endian payload in a big endian message.
+        types.ExecuteCommandType.REINIT_SERVICE: (b"\x01\x02\x03\x04", b"\x08\x04\x03\x02\x01"),
+        types.ExecuteCommandType.AFE_READ_ALL_REGISTERS: (b"", b"\xa1"),
+        types.ExecuteCommandType.AFE_WRITE_REGISTER: (b"\x10\x00\x00\x00\x05", b"\xa2\x10\x00\x00\x00\x05"),
+        types.ExecuteCommandType.AFE_CALIBRATION_COMMAND: (single_byte_value, b"\xa3\x2a"),
+        types.ExecuteCommandType.AFE_GAIN_SETTING: (single_byte_value, b"\xa4\x2a"),
+    }
+    assert set(expected_bodies) == set(types.ExecuteCommandType), "a command type has no encode expectation"
+
+    for command_type, (value, expected_body) in expected_bodies.items():
+        message = codec.ExecuteCommand(command_id=command_type.value, value=value)
+        encoded = message.encode()
+        body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+        assert body == expected_body, command_type.name
+
+        decoded = codec.decode(encoded)
+        assert isinstance(decoded, codec.ExecuteCommand)
+        assert decoded.command_id == command_type.value, command_type.name
+
+
+def test_reinit_service_accepts_int_value() -> None:
+    """The int branch packs big endian, unlike the bytes branch which reverses."""
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=0x01020304)
+    encoded = message.encode()
+    body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+    assert body == b"\x08\x01\x02\x03\x04"
+
+
+def test_reinit_service_defaults_to_zero_parameter() -> None:
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=None)
+    encoded = message.encode()
+    body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+    assert body == b"\x08\x00\x00\x00\x00"

--- a/tests/test_execute_command.py
+++ b/tests/test_execute_command.py
@@ -175,3 +175,22 @@ def test_reinit_service_defaults_to_zero_parameter() -> None:
     encoded = message.encode()
     body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
     assert body == b"\x08\x00\x00\x00\x00"
+
+
+@pytest.mark.parametrize("partial", [b"\x01", b"\x01\x02", b"\x01\x02\x03"])
+def test_reinit_service_rejects_partial_parameter(partial: bytes) -> None:
+    """A 1-3 byte payload used to raise a bare IndexError from indexing value[3].
+
+    Empty bytes still means "zero parameter" - only a partial one is an error, matching
+    how AFE_WRITE_REGISTER reports a wrong-sized payload.
+    """
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=partial)
+    with pytest.raises(ValueError, match="REINIT_SERVICE requires 4 bytes"):
+        message.encode()
+
+
+def test_reinit_service_empty_bytes_still_means_zero() -> None:
+    message = codec.ExecuteCommand(command_id=types.ExecuteCommandType.REINIT_SERVICE.value, value=b"")
+    encoded = message.encode()
+    body = encoded[codec.Message.hdr_len : len(encoded) - codec.Message.crc_len]
+    assert body == b"\x08\x00\x00\x00\x00"

--- a/tests/test_file_codec.py
+++ b/tests/test_file_codec.py
@@ -1,3 +1,5 @@
+import struct
+
 import pytest
 
 from embodycodec import file_codec as codec
@@ -216,7 +218,36 @@ def test_decode_battery_diagnostics() -> None:
 
 
 def test_decode_generic_message() -> None:
-    msg = codec.decode_message(bytes.fromhex("bb0b35010000000200000003000400050006000700080009000A00"))
+    raw = bytes.fromhex("bb0b35010000000200000003000400050006000700080009000A00")
+    msg = codec.decode_message(raw)
     assert isinstance(msg, codec.BatteryDiagnostics)
-    assert 24 == msg.length()
-    assert 24 == codec.BatteryDiagnostics.default_length()
+    # 26, not 24: every other TimetickedMessage counts the two-byte timestamp in its
+    # length, and a stream parser advances by 1 (type byte) + length(). BatteryDiagnostics
+    # used to report 24, so it desynced the stream by two bytes on every such record.
+    assert 26 == msg.length()
+    assert 26 == codec.BatteryDiagnostics.default_length()
+    assert len(raw) == 1 + msg.length()
+
+
+def test_timeticked_length_includes_timestamp() -> None:
+    """A file stream is walked by advancing 1 + length(), so length() must span the record.
+
+    Pins the convention BatteryDiagnostics used to violate. Iterates the registry rather
+    than a hand-written list, so a future message type cannot reintroduce the bug.
+    """
+    struct_driven = [
+        message_class
+        for message_class in codec._FILE_MESSAGE_REGISTRY.values()
+        if issubclass(message_class, codec.TimetickedMessage) and message_class.unpack_format
+    ]
+    assert len(struct_driven) >= 10, "registry lookup found suspiciously few message types"
+
+    for message_class in struct_driven:
+        # The leading H is the two-LSB timestamp; without it, length() under-reports the
+        # record and a stream parser desyncs by two bytes.
+        assert message_class.unpack_format[1] == "H", message_class.__name__
+        assert message_class.default_length() == struct.calcsize(message_class.unpack_format), message_class.__name__
+
+    # Types that compute default_length() by hand instead of from a struct format.
+    for message_class, expected in [(codec.PpgRaw, 8), (codec.PpgRawAll, 11)]:
+        assert message_class.default_length() == expected, message_class.__name__

--- a/tests/test_variable_length_payloads.py
+++ b/tests/test_variable_length_payloads.py
@@ -187,6 +187,33 @@ def test_attribute_payload_at_the_length_limit_is_accepted() -> None:
     assert decoded.value == at_limit
 
 
+@pytest.mark.parametrize("fmt", [0, 1, 2, 3])
+@pytest.mark.parametrize(("no_of_ecgs", "no_of_ppgs"), [(0, 0), (1, 1), (1, 0), (0, 1)])
+def test_pulse_raw_list_accepts_short_but_complete_message(fmt: int, no_of_ecgs: int, no_of_ppgs: int) -> None:
+    """A message can legitimately be as short as 3 bytes; the guard used to demand 10.
+
+    The smallest cases here (1-byte samples, few channels) all encode to under 10 bytes,
+    so `types.PulseRawList.decode` rejected complete, valid messages outright. The
+    `file_codec` twin already guarded on 3 - this is the other half of that drift.
+    """
+    message = types.PulseRawList(
+        tick=811,
+        format=fmt,
+        no_of_ecgs=no_of_ecgs,
+        no_of_ppgs=no_of_ppgs,
+        ecgs=[7] * no_of_ecgs,
+        ppgs=[9] * no_of_ppgs,
+    )
+    encoded = message.encode()
+    assert len(encoded) == types.PulseRawList.header_length + (no_of_ecgs + no_of_ppgs) * (fmt + 1)
+
+    assert types.PulseRawList.decode(encoded) == message
+    from_file = file_codec.PulseRawList.decode(encoded)
+    assert from_file.ecgs == message.ecgs
+    assert from_file.ppgs == message.ppgs
+    assert from_file.length() == len(encoded)
+
+
 def test_system_status_names_empty_round_trip() -> None:
     """decode(b"") yields an empty list, and encoding it raised IndexError."""
     decoded = attributes.SystemStatusNamesAttribute.decode(b"")

--- a/tests/test_variable_length_payloads.py
+++ b/tests/test_variable_length_payloads.py
@@ -1,0 +1,246 @@
+"""Regression tests for variable-length payloads.
+
+The original test suite only asserted round-trips for fixed-size payloads, which hid a
+family of defects in every attribute and complex type whose encoded size is not static.
+Each test here fails against the code as it was before these were fixed.
+"""
+
+import pytest
+
+from embodycodec import attributes
+from embodycodec import codec
+from embodycodec import file_codec
+from embodycodec import types
+
+
+VARIABLE_LENGTH_ATTRIBUTES = [
+    attributes.ModelAttribute("EMB123"),
+    attributes.VendorAttribute("Aidee"),
+    attributes.SystemStatusNamesAttribute(["cpu", "flash", "afe"]),
+    attributes.SystemStatusAttribute(
+        types.SystemStatus(
+            status=[types.SystemStatusType.OK, types.SystemStatusType.WARNING],
+            worst=[types.SystemStatusType.OK, types.SystemStatusType.FAILED],
+        )
+    ),
+    attributes.PulseRawListAttribute(
+        types.PulseRawList(
+            tick=843,
+            format=3,
+            no_of_ecgs=1,
+            no_of_ppgs=3,
+            ecgs=[1],
+            ppgs=[1000, 100, 5],
+        )
+    ),
+]
+
+
+@pytest.mark.parametrize("attribute", VARIABLE_LENGTH_ATTRIBUTES, ids=lambda a: type(a).__name__)
+def test_set_attribute_declares_real_payload_length(attribute: attributes.Attribute) -> None:
+    """SetAttribute wrote a length byte of 0 for every variable-length attribute.
+
+    The payload still went out on the wire, but the length field said zero, so a
+    conforming parser dropped the value.
+    """
+    encoded = codec.SetAttribute(attribute_id=attribute.attribute_id, value=attribute).encode()
+
+    expected_payload = attribute.encode()
+    declared_length = encoded[codec.Message.hdr_len + 1]
+    assert declared_length == len(expected_payload)
+    assert declared_length > 0
+
+    decoded = codec.decode(encoded)
+    assert isinstance(decoded, codec.SetAttribute)
+    assert decoded.value == attribute
+
+
+@pytest.mark.parametrize("attribute", VARIABLE_LENGTH_ATTRIBUTES, ids=lambda a: type(a).__name__)
+def test_get_attribute_response_round_trip(attribute: attributes.Attribute) -> None:
+    """GetAttributeResponse already derived its length correctly - guard against regression."""
+    response = codec.GetAttributeResponse(
+        attribute_id=attribute.attribute_id,
+        changed_at=1,
+        reporting=types.Reporting(interval=1, on_change=1),
+        value=attribute,
+    )
+    decoded = codec.decode(response.encode())
+    assert isinstance(decoded, codec.GetAttributeResponse)
+    assert decoded.value == attribute
+
+
+def test_send_file_response_preserves_file_crc() -> None:
+    """The payload field used to be named `crc`, colliding with Message.crc.
+
+    Message.decode assigns the footer CRC to `.crc` after construction, so the decoded
+    file CRC was silently replaced by the message CRC.
+    """
+    response = codec.SendFileResponse(file_crc=9)
+    encoded = response.encode()
+    assert encoded == b"\xc3\x00\x07\x00\t\xd8\xdf"
+
+    decoded = codec.decode(encoded)
+    assert isinstance(decoded, codec.SendFileResponse)
+    assert decoded.file_crc == 9
+    assert decoded.crc == 0xD8DF  # message footer CRC, a separate value
+    assert decoded.length == 7
+
+
+# format selects the sample width: 0 -> 1 byte, 1 -> 2, 2 -> 3, 3 -> 4.
+# to_format_and_lengths() masks ecgs to 2 bits and ppgs to 4 bits, so those are the caps.
+@pytest.mark.parametrize("fmt", [0, 1, 2, 3])
+@pytest.mark.parametrize(("no_of_ecgs", "no_of_ppgs"), [(0, 0), (1, 3), (3, 15), (0, 15), (3, 0)])
+def test_pulse_raw_list_length_matches_encoded_size(fmt: int, no_of_ecgs: int, no_of_ppgs: int) -> None:
+    """length() returned 0 on a constructed instance and under-reported by 2 after decode.
+
+    Parameterised over every sample width, since the width table is what length() and the
+    truncation check both depend on.
+    """
+    pulse_raw_list = types.PulseRawList(
+        tick=843,
+        format=fmt,
+        no_of_ecgs=no_of_ecgs,
+        no_of_ppgs=no_of_ppgs,
+        ecgs=[1] * no_of_ecgs,
+        ppgs=[1] * no_of_ppgs,
+    )
+    encoded = pulse_raw_list.encode()
+    assert pulse_raw_list.length() == len(encoded)
+
+    decoded = types.PulseRawList.decode(encoded)
+    assert decoded.length() == len(encoded)
+    assert decoded.len == len(encoded)
+    assert decoded == pulse_raw_list
+
+
+@pytest.mark.parametrize("fmt", [0, 1, 2, 3])
+def test_pulse_raw_list_rejects_truncation_for_every_sample_width(fmt: int) -> None:
+    full = types.PulseRawList(
+        tick=843,
+        format=fmt,
+        no_of_ecgs=3,
+        no_of_ppgs=15,
+        ecgs=[1, 2, 3],
+        ppgs=list(range(15)),
+    ).encode()
+
+    with pytest.raises(BufferError):
+        types.PulseRawList.decode(full[:-1])
+    with pytest.raises(BufferError):
+        file_codec.PulseRawList.decode(full[:-1])
+
+
+@pytest.mark.parametrize("truncate_to", [3, 10, 18])
+def test_pulse_raw_list_rejects_truncated_buffer(truncate_to: int) -> None:
+    """A short buffer used to yield zeroed samples instead of asking for more data.
+
+    Parameterised over both implementations so the two copies cannot drift apart again.
+    """
+    full = types.PulseRawList(
+        tick=843,
+        format=3,
+        no_of_ecgs=1,
+        no_of_ppgs=3,
+        ecgs=[1],
+        ppgs=[1000, 100, 5],
+    ).encode()
+    assert len(full) > truncate_to
+
+    with pytest.raises(BufferError):
+        types.PulseRawList.decode(full[:truncate_to])
+    with pytest.raises(BufferError):
+        file_codec.PulseRawList.decode(full[:truncate_to])
+
+
+def test_oversized_attribute_payload_is_rejected_clearly() -> None:
+    """The length field is one byte, so a >255 byte payload cannot be represented.
+
+    Deriving the real length (rather than always writing 0) exposes this; struct's own
+    error names only the format character, so raise something that names the problem.
+    """
+    oversized = attributes.SystemStatusNamesAttribute([f"sensor{i:03d}" for i in range(30)])
+    assert len(oversized.encode()) > codec.MAX_ATTRIBUTE_LENGTH
+
+    for message in (
+        codec.SetAttribute(attribute_id=oversized.attribute_id, value=oversized),
+        codec.AttributeChanged(changed_at=1, attribute_id=oversized.attribute_id, value=oversized),
+        codec.GetAttributeResponse(
+            attribute_id=oversized.attribute_id,
+            changed_at=1,
+            reporting=types.Reporting(interval=1, on_change=1),
+            value=oversized,
+        ),
+    ):
+        with pytest.raises(ValueError, match="protocol length field"):
+            message.encode()
+
+
+def test_attribute_payload_at_the_length_limit_is_accepted() -> None:
+    """Exactly 255 bytes must still encode - the check is > not >=."""
+    at_limit = attributes.ModelAttribute("x" * codec.MAX_ATTRIBUTE_LENGTH)
+    assert len(at_limit.encode()) == codec.MAX_ATTRIBUTE_LENGTH
+
+    encoded = codec.SetAttribute(attribute_id=at_limit.attribute_id, value=at_limit).encode()
+    assert encoded[codec.Message.hdr_len + 1] == codec.MAX_ATTRIBUTE_LENGTH
+    decoded = codec.decode(encoded)
+    assert isinstance(decoded, codec.SetAttribute)
+    assert decoded.value == at_limit
+
+
+def test_system_status_names_empty_round_trip() -> None:
+    """decode(b"") yields an empty list, and encoding it raised IndexError."""
+    decoded = attributes.SystemStatusNamesAttribute.decode(b"")
+    assert decoded.value == []
+    assert decoded.encode() == b""
+
+
+def test_system_status_names_round_trip() -> None:
+    attribute = attributes.SystemStatusNamesAttribute(["cpu", "flash", "afe"])
+    assert attribute.encode() == b"cpu,flash,afe"
+    assert attributes.SystemStatusNamesAttribute.decode(attribute.encode()) == attribute
+
+
+@pytest.mark.parametrize("value", [0x000000, 0x050202, 0x7FFFFF, 0x800000, 0x900000, 0xFFFFFF])
+def test_firmware_version_round_trip(value: int) -> None:
+    """encode() used signed=True while decode() used signed=False.
+
+    Anything from 0x800000 up raised OverflowError on encode.
+    """
+    attribute = attributes.FirmwareVersionAttribute(value)
+    encoded = attribute.encode()
+    assert len(encoded) == 3
+    assert attributes.FirmwareVersionAttribute.decode(encoded) == attribute
+
+
+def test_firmware_version_formatted_value_keeps_major_version() -> None:
+    """The mask was 0xFFFFF (20 bits), which truncated the top nibble of the major byte."""
+    assert attributes.FirmwareVersionAttribute(0x900000).formatted_value() == "144.00.00"
+    assert attributes.FirmwareVersionAttribute(0x050301).formatted_value() == "05.03.01"
+
+
+def test_alarm_round_trip() -> None:
+    """changed_at/alarm_type were annotated `int | None`, which ">QB" cannot pack."""
+    alarm = codec.Alarm(changed_at=1, alarm_type=0x01)
+    decoded = codec.decode(alarm.encode())
+    assert isinstance(decoded, codec.Alarm)
+    assert decoded == alarm
+    assert decoded.alarm_message() == "Low battery"
+
+
+@pytest.mark.parametrize("message_class", [file_codec.PulseBlockEcg, file_codec.PulseBlockPpg])
+def test_pulse_block_encode_is_not_a_silent_stub(
+    message_class: type[file_codec.PulseBlockEcg] | type[file_codec.PulseBlockPpg],
+) -> None:
+    """encode() returned two zero bytes regardless of contents, which looks like valid output."""
+    message = message_class(time=1, channel=0, num_samples=1, samples=[5], pkg_length=14)
+    with pytest.raises(NotImplementedError):
+        message.encode()
+
+
+@pytest.mark.parametrize("message_class", [file_codec.PulseBlockEcg, file_codec.PulseBlockPpg])
+def test_pulse_block_rejects_short_header(
+    message_class: type[file_codec.PulseBlockEcg] | type[file_codec.PulseBlockPpg],
+) -> None:
+    """PulseBlockPpg guarded on 13 bytes while the header is 14."""
+    with pytest.raises(BufferError):
+        message_class.decode(bytes(file_codec.PULSE_BLOCK_HEADER_LENGTH - 1))

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "embody-codec"
-version = "1.0.40"
+version = "2.0.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Recovers #815, #816 and #817, which were merged but **never reached `main`**, and cuts the 2.0.0 release that consequently did not happen.

## What went wrong

The four PRs were stacked — each based on the one below it. This repo has *automatically delete head branches* enabled. Merging them in quick succession (all four within 91 seconds) produced:

| PR | Base at merge | Merge commit | Landed on `main`? |
|----|---------------|--------------|-------------------|
| #814 | `main` | `65ee79d4` | ✅ yes |
| #815 | `chore/tooling-hardening` | `7aef8051` | ❌ base branch already deleted |
| #816 | `fix/wire-format-bugs` | `838469a4` | ❌ base branch already deleted |
| #817 | `refactor/deduplicate-codecs` | `67989a05` | ❌ base branch already deleted |

GitHub normally retargets an open PR onto `main` when its base branch is deleted, but the merges landed faster than that retargeting ran. So #815–#817 each merged into a branch that had just been deleted. Their merge commits exist as unreferenced objects — reachable via the API, pointed at by nothing.

`main` therefore has only the tooling PR, and is still on `version = "1.0.40"`.

## Why no release

The Release workflow ran on `main` and **succeeded** — it did exactly what it should:

```
Release / Detect and tag new version          success   (no version change -> no tag)
Release / Bump version for developmental release  success
Release / Build package                       success
Release / Publish package on PyPI             skipped   <-- gated on check-version.outputs.tag
Release / Publish the release notes           success
```

Nothing is broken in the release automation. The release commit simply never arrived.

## This PR

The full stack, rebuilt as a single PR against `main` so nothing can be stranded again. Content is identical to what was reviewed and approved on #814–#817, including the Copilot review fixes and Kyrre's co-authored `PulseRawList` commit. `main` is merged in, so this is a fast-forwardable superset.

- 13 commits, 13 files, 218 tests passing
- `make check` clean
- The version-extraction command in `release.yml` returns `2.0.0`
- `v2.0.0` is free — only `v1.0.40` exists

> [!IMPORTANT]
> **Merge with a merge commit, not squash.** Squashing collapses all 13 commits into one, losing the per-change history that made this reviewable and dropping the `Co-authored-by: Kyrre Aalerud` trailer.

> [!WARNING]
> Merging this **publishes 2.0.0 to PyPI** and tags `v2.0.0`. It is a major release — see the "Upgrading to 2.0.0" section in the README for the four breaking changes.

## Preventing a recurrence

Stacked PRs and *auto-delete head branches* do not combine safely when merged in rapid succession. Either merge stacked PRs one at a time and wait for the retarget to land, or avoid stacking and use a single integration branch as here.
